### PR TITLE
Fix reflector memory poisoning and skill frontmatter parsing

### DIFF
--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -160,7 +160,19 @@ Rules:
 - Category must be exactly one of: PROFILE (user attributes/preferences), KNOWLEDGE (facts/expertise), EVENT (significant things that happened)
 - If a new memory updates or supersedes an existing one, add "supersedes_id": <id> to replace it
 - Output ONLY valid JSON array: [{"content":"...","category":"PROFILE","supersedes_id":null}]
-- If nothing worth remembering: []"#;
+- If nothing worth remembering: []
+
+CRITICAL — how to memorize bugs and problems:
+- NEVER describe broken behavior as a fact (e.g. "tool calls were broken", "agent typed tool calls as text"). This causes the agent to repeat the broken behavior in future sessions.
+- Instead, frame bugs as ACTION ITEMS with the correct behavior. Use "TODO: fix" or "ensure" phrasing that tells the agent what TO DO, not what went wrong.
+- Examples:
+  BAD: "proactive-agent skill broke tool calling — tool calls posted as text" (agent reads this and keeps doing it)
+  GOOD: "TODO: ensure tool calls always execute via tool system, never output as plain text"
+  BAD: "got 401 authentication error on Discord"
+  GOOD: "TODO: check API key config if Discord auth fails"
+  BAD: "user said agent isn't following instructions"
+  GOOD: "TODO: strictly follow TOOLS.md rules for every tool call"
+- The memory should tell the agent HOW TO BEHAVE CORRECTLY, never describe the broken behavior."#;
 
 fn jaccard_similar(a: &str, b: &str, threshold: f64) -> bool {
     use std::collections::HashSet;
@@ -557,7 +569,7 @@ async fn reflect_for_chat(state: &Arc<AppState>, chat_id: i64) {
             #[cfg(feature = "sqlite-vec")]
             {
                 if let Some(provider) = &state.embedding {
-                    if let Ok(query_vec) = provider.embed(content).await {
+                    if let Ok(query_vec) = provider.embed(&content).await {
                         let nearest = call_blocking(state.db.clone(), move |db| {
                             db.knn_memories(chat_id, &query_vec, 1)
                         })


### PR DESCRIPTION
## Summary

- **Reflector memory poisoning fix**: When a user tells the agent about a bug (e.g. "you're typing tool calls as text, stop it"), the reflector would memorize the broken behavior as a fact. On the next session, the agent reads "I type tool calls as text" from memory and continues doing it — a self-reinforcing loop. The fix updates the reflector prompt to frame bugs as action items ("TODO: ensure tool calls execute properly") instead of descriptions of broken behavior.

- **Single-line YAML frontmatter support**: LLMs sometimes write SKILL.md files with frontmatter collapsed onto a single line (`--- name: foo description: bar ---`). The parser requires `---\n` (newline after dashes) and silently rejects these. Added `normalize_single_line_frontmatter()` that splits known keys onto separate lines before parsing.

## Test plan

- [x] All existing tests pass
- [x] New tests for single-line frontmatter parsing (`test_parse_skill_md_single_line_frontmatter`, `test_normalize_single_line_frontmatter`)
- [ ] Verify reflector creates action-item memories instead of problem descriptions when user reports bugs

🤖 Generated with [Claude Code](https://claude.com/claude-code)