### PR TITLE
fix(setup,config): make channel enablement explicit and prevent false…

### DIFF
--- a/microclaw.config.example.yaml
+++ b/microclaw.config.example.yaml
@@ -1,10 +1,6 @@
 # MicroClaw configuration
 # Copy this file to microclaw.config.yaml and fill in the required values.
 
-# Telegram bot token from @BotFather
-telegram_bot_token: ""
-# Bot username without @
-bot_username: ""
 
 # LLM provider (anthropic, openai-codex, ollama, openai, openrouter, deepseek, google, etc.)
 llm_provider: "anthropic"
@@ -62,9 +58,6 @@ timezone: "UTC"
 max_session_messages: 40
 compact_keep_recent: 20
 
-# Telegram group allowlist (empty = allow all groups)
-# allowed_groups: []
-
 # Control chats can operate across chats (send_message/schedule/memory global/export/todo).
 # Non-control chats are restricted to their own chat_id.
 # control_chat_ids: []
@@ -75,33 +68,38 @@ compact_keep_recent: 20
 # whatsapp_verify_token: ""
 # whatsapp_webhook_port: 8080
 
-# Discord (optional)
-# discord_bot_token: ""
-# discord_allowed_channels: []
-
-# Slack (optional, Socket Mode) — configure under `channels:`
-# channels:
-#   slack:
-#     bot_token: "xoxb-..."
-#     app_token: "xapp-..."
-#     allowed_channels: []
-
-# Feishu / Lark (optional) — configure under `channels:`
-# channels:
-#   feishu:
-#     app_id: "cli_xxx"
-#     app_secret: "xxx"
-#     connection_mode: "websocket"   # "websocket" (default) or "webhook"
-#     domain: "feishu"               # "feishu" (China), "lark" (international), or custom URL
-#     allowed_chats: []
-#     # Webhook-only settings:
-#     # webhook_path: "/feishu/events"
-#     # verification_token: ""
-#     # encrypt_key: ""
+channels:
+  web:
+    enabled: true
+  telegram:
+    enabled: false
+    bot_token: ""
+    bot_username: ""
+    # Telegram group allowlist (empty = allow all groups)
+    # allowed_groups: []
+  discord:
+    enabled: false
+    bot_token: ""
+    # allowed_channels: []
+  # slack:
+  #   enabled: false
+  #   bot_token: "xoxb-..."
+  #   app_token: "xapp-..."
+  #   allowed_channels: []
+  # feishu:
+  #   enabled: false
+  #   app_id: "cli_xxx"
+  #   app_secret: "xxx"
+  #   connection_mode: "websocket"   # "websocket" (default) or "webhook"
+  #   domain: "feishu"               # "feishu" (China), "lark" (international), or custom URL
+  #   allowed_chats: []
+  #   # Webhook-only settings:
+  #   # webhook_path: "/feishu/events"
+  #   # verification_token: ""
+  #   # encrypt_key: ""
 
 # Local web UI (optional)
-# Enable built-in local web chat + config panel
-web_enabled: true
+# Channel on/off is controlled by `channels.web.enabled`.
 # Bind address for local web UI
 web_host: "127.0.0.1"
 # Port for local web UI
@@ -119,6 +117,13 @@ web_rate_window_seconds: 10
 web_run_history_limit: 512
 # Idle cleanup TTL for web session quota/locks (seconds)
 web_session_idle_ttl_seconds: 300
+
+# Legacy flat channel fields (backward compatibility only; prefer `channels:` above):
+# telegram_bot_token: ""
+# bot_username: ""
+# discord_bot_token: null
+# discord_allowed_channels: []
+# web_enabled: true
 
 # Soul file: defines your bot's personality, voice, values, and behavior.
 # Supports markdown format. If not set, checks data_dir/SOUL.md then ./SOUL.md.

--- a/src/config.rs
+++ b/src/config.rs
@@ -268,6 +268,38 @@ impl Config {
         Ok(None)
     }
 
+    fn inferred_channel_enabled(&self, channel: &str) -> bool {
+        match channel {
+            "telegram" => {
+                !self.telegram_bot_token.trim().is_empty() || self.channels.contains_key("telegram")
+            }
+            "discord" => {
+                self.discord_bot_token
+                    .as_deref()
+                    .map(|v| !v.trim().is_empty())
+                    .unwrap_or(false)
+                    || self.channels.contains_key("discord")
+            }
+            "web" => self.web_enabled || self.channels.contains_key("web"),
+            _ => self.channels.contains_key(channel),
+        }
+    }
+
+    fn explicit_channel_enabled(&self, channel: &str) -> Option<bool> {
+        self.channels
+            .get(channel)
+            .and_then(|v| v.get("enabled"))
+            .and_then(|v| v.as_bool())
+    }
+
+    pub fn channel_enabled(&self, channel: &str) -> bool {
+        let needle = channel.trim().to_lowercase();
+        if let Some(explicit) = self.explicit_channel_enabled(&needle) {
+            return explicit;
+        }
+        self.inferred_channel_enabled(&needle)
+    }
+
     /// Load config from YAML file.
     pub fn load() -> Result<Self, MicroClawError> {
         let yaml_path = Self::resolve_config_path()?;
@@ -347,9 +379,16 @@ impl Config {
                 self.embedding_dim = None;
             }
         }
-        if self.web_enabled && !is_local_web_host(&self.web_host) && self.web_auth_token.is_none() {
+        let web_enabled_effective = self
+            .explicit_channel_enabled("web")
+            .unwrap_or(self.web_enabled);
+        if web_enabled_effective
+            && !is_local_web_host(&self.web_host)
+            && self.web_auth_token.is_none()
+        {
             return Err(MicroClawError::Config(
-                "web_auth_token is required when web_enabled=true and web_host is not local".into(),
+                "web_auth_token is required when web channel is enabled and web_host is not local"
+                    .into(),
             ));
         }
         if self.web_max_inflight_per_session == 0 {
@@ -400,6 +439,7 @@ impl Config {
                 self.channels.insert(
                     "telegram".into(),
                     serde_yaml::to_value(serde_json::json!({
+                        "enabled": true,
                         "bot_token": self.telegram_bot_token,
                         "bot_username": self.bot_username,
                         "allowed_groups": self.allowed_groups,
@@ -412,6 +452,7 @@ impl Config {
                     self.channels.insert(
                         "discord".into(),
                         serde_yaml::to_value(serde_json::json!({
+                            "enabled": true,
                             "bot_token": token,
                             "allowed_channels": self.discord_allowed_channels,
                         }))
@@ -434,21 +475,27 @@ impl Config {
         }
 
         // Validate required fields
-        let has_telegram =
+        let configured_telegram =
             !self.telegram_bot_token.trim().is_empty() || self.channels.contains_key("telegram");
-        let has_discord = self
+        let configured_discord = self
             .discord_bot_token
             .as_deref()
             .map(|v| !v.trim().is_empty())
             .unwrap_or(false)
             || self.channels.contains_key("discord");
-        let has_slack = self.channels.contains_key("slack");
-        let has_feishu = self.channels.contains_key("feishu");
-        let has_web = self.web_enabled || self.channels.contains_key("web");
+        let configured_slack = self.channels.contains_key("slack");
+        let configured_feishu = self.channels.contains_key("feishu");
+        let configured_web = self.web_enabled || self.channels.contains_key("web");
+
+        let has_telegram = self.channel_enabled("telegram") && configured_telegram;
+        let has_discord = self.channel_enabled("discord") && configured_discord;
+        let has_slack = self.channel_enabled("slack") && configured_slack;
+        let has_feishu = self.channel_enabled("feishu") && configured_feishu;
+        let has_web = self.channel_enabled("web") && configured_web;
 
         if !(has_telegram || has_discord || has_slack || has_feishu || has_web) {
             return Err(MicroClawError::Config(
-                "At least one channel must be enabled: telegram_bot_token, discord_bot_token, channels.slack, channels.feishu, or web_enabled=true".into(),
+                "At least one channel must be enabled and configured (via channels.<name>.enabled or legacy channel settings)".into(),
             ));
         }
         if self.api_key.is_empty() && !provider_allows_empty_api_key(&self.llm_provider) {
@@ -803,6 +850,27 @@ mod tests {
     }
 
     #[test]
+    fn test_post_deserialize_channel_enabled_flag_overrides_legacy_inference() {
+        let yaml = "telegram_bot_token: tok\nbot_username: bot\ndiscord_bot_token: discord_tok\napi_key: key\nchannels:\n  telegram:\n    enabled: false\n  discord:\n    enabled: true\n  web:\n    enabled: false\n";
+        let mut config: Config = serde_yaml::from_str(yaml).unwrap();
+        config.post_deserialize().unwrap();
+
+        assert!(!config.channel_enabled("telegram"));
+        assert!(config.channel_enabled("discord"));
+        assert!(!config.channel_enabled("web"));
+    }
+
+    #[test]
+    fn test_post_deserialize_channel_enabled_flag_controls_web() {
+        let yaml =
+            "api_key: key\ndiscord_bot_token: discord_tok\nchannels:\n  web:\n    enabled: false\n";
+        let mut config: Config = serde_yaml::from_str(yaml).unwrap();
+        config.post_deserialize().unwrap();
+
+        assert!(!config.channel_enabled("web"));
+    }
+
+    #[test]
     fn test_post_deserialize_openai_default_model() {
         let yaml =
             "telegram_bot_token: tok\nbot_username: bot\napi_key: key\nllm_provider: openai\n";
@@ -984,7 +1052,7 @@ mod tests {
         let err = config.post_deserialize().unwrap_err();
         assert!(err
             .to_string()
-            .contains("web_auth_token is required when web_enabled=true"));
+            .contains("web_auth_token is required when web channel is enabled"));
     }
 
     #[test]

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -358,7 +358,7 @@ struct PickerState {
 
 impl SetupApp {
     fn channel_options() -> Vec<&'static str> {
-        let mut opts = vec!["telegram", "discord"];
+        let mut opts = vec!["web", "telegram", "discord"];
         for ch in DYNAMIC_CHANNELS {
             opts.push(ch.name);
         }
@@ -380,7 +380,7 @@ impl SetupApp {
         let enabled_channels = existing
             .get("ENABLED_CHANNELS")
             .cloned()
-            .unwrap_or_default();
+            .unwrap_or_else(|| "web".into());
 
         let mut app = Self {
             fields: vec![
@@ -588,29 +588,50 @@ impl SetupApp {
                 if let Ok(config) = serde_yaml::from_str::<crate::config::Config>(&content) {
                     let mut map = HashMap::new();
                     let mut enabled = Vec::new();
-                    if !config.telegram_bot_token.trim().is_empty() {
-                        enabled.push("telegram");
-                    }
-                    if config
-                        .discord_bot_token
-                        .as_deref()
-                        .map(|v| !v.trim().is_empty())
-                        .unwrap_or(false)
-                    {
-                        enabled.push("discord");
-                    }
-                    for ch in DYNAMIC_CHANNELS {
-                        if config.channels.contains_key(ch.name) {
-                            enabled.push(ch.name);
+                    for channel in Self::channel_options() {
+                        if config.channel_enabled(channel) {
+                            enabled.push(channel.to_string());
                         }
                     }
                     map.insert("ENABLED_CHANNELS".into(), enabled.join(","));
-                    map.insert("TELEGRAM_BOT_TOKEN".into(), config.telegram_bot_token);
-                    map.insert("BOT_USERNAME".into(), config.bot_username);
-                    map.insert(
-                        "DISCORD_BOT_TOKEN".into(),
-                        config.discord_bot_token.unwrap_or_default(),
-                    );
+                    let telegram_bot_token = if !config.telegram_bot_token.trim().is_empty() {
+                        config.telegram_bot_token
+                    } else {
+                        config
+                            .channels
+                            .get("telegram")
+                            .and_then(|v| v.get("bot_token"))
+                            .and_then(|v| v.as_str())
+                            .unwrap_or_default()
+                            .to_string()
+                    };
+                    let bot_username = if !config.bot_username.trim().is_empty() {
+                        config.bot_username
+                    } else {
+                        config
+                            .channels
+                            .get("telegram")
+                            .and_then(|v| v.get("bot_username"))
+                            .and_then(|v| v.as_str())
+                            .unwrap_or_default()
+                            .to_string()
+                    };
+                    let discord_bot_token = if let Some(v) =
+                        config.discord_bot_token.filter(|v| !v.trim().is_empty())
+                    {
+                        v
+                    } else {
+                        config
+                            .channels
+                            .get("discord")
+                            .and_then(|v| v.get("bot_token"))
+                            .and_then(|v| v.as_str())
+                            .unwrap_or_default()
+                            .to_string()
+                    };
+                    map.insert("TELEGRAM_BOT_TOKEN".into(), telegram_bot_token);
+                    map.insert("BOT_USERNAME".into(), bot_username);
+                    map.insert("DISCORD_BOT_TOKEN".into(), discord_bot_token);
                     // Extract dynamic channel configs
                     for ch in DYNAMIC_CHANNELS {
                         if let Some(ch_map) = config.channels.get(ch.name) {
@@ -669,22 +690,47 @@ impl SetupApp {
     }
 
     fn next(&mut self) {
-        if self.selected + 1 < self.fields.len() {
-            self.selected += 1;
+        let visible = self.visible_field_indices();
+        if visible.is_empty() {
+            return;
+        }
+        if let Some(pos) = visible.iter().position(|idx| *idx == self.selected) {
+            if pos + 1 < visible.len() {
+                self.selected = visible[pos + 1];
+            }
+        } else {
+            self.selected = visible[0];
         }
     }
 
     fn prev(&mut self) {
-        if self.selected > 0 {
-            self.selected -= 1;
+        let visible = self.visible_field_indices();
+        if visible.is_empty() {
+            return;
+        }
+        if let Some(pos) = visible.iter().position(|idx| *idx == self.selected) {
+            if pos > 0 {
+                self.selected = visible[pos - 1];
+            }
+        } else {
+            self.selected = visible[0];
         }
     }
 
     fn selected_field_mut(&mut self) -> &mut Field {
+        self.ensure_selected_visible();
         &mut self.fields[self.selected]
     }
 
     fn selected_field(&self) -> &Field {
+        if self.selected < self.fields.len()
+            && self.is_field_visible(&self.fields[self.selected].key)
+        {
+            return &self.fields[self.selected];
+        }
+        if let Some(first_visible) = self.visible_field_indices().first().copied() {
+            return &self.fields[first_visible];
+        }
         &self.fields[self.selected]
     }
 
@@ -724,6 +770,75 @@ impl SetupApp {
 
     fn channel_enabled(&self, channel: &str) -> bool {
         self.enabled_channels().iter().any(|c| c == channel)
+    }
+
+    fn dynamic_field_channel(key: &str) -> Option<&'static str> {
+        for ch in DYNAMIC_CHANNELS {
+            for f in ch.fields {
+                if key == dynamic_field_key(ch.name, f.yaml_key) {
+                    return Some(ch.name);
+                }
+            }
+        }
+        None
+    }
+
+    fn is_field_visible(&self, key: &str) -> bool {
+        match key {
+            "TELEGRAM_BOT_TOKEN" | "BOT_USERNAME" => self.channel_enabled("telegram"),
+            "DISCORD_BOT_TOKEN" => self.channel_enabled("discord"),
+            _ => Self::dynamic_field_channel(key)
+                .map(|ch| self.channel_enabled(ch))
+                .unwrap_or(true),
+        }
+    }
+
+    fn visible_field_indices(&self) -> Vec<usize> {
+        self.fields
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, field)| {
+                if self.is_field_visible(&field.key) {
+                    Some(idx)
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    fn ensure_selected_visible(&mut self) {
+        let visible = self.visible_field_indices();
+        if visible.is_empty() {
+            return;
+        }
+        if self.selected >= self.fields.len() {
+            self.selected = visible[0];
+            return;
+        }
+        if self.is_field_visible(&self.fields[self.selected].key) {
+            return;
+        }
+        if let Some(next_idx) = visible.iter().copied().find(|idx| *idx > self.selected) {
+            self.selected = next_idx;
+            return;
+        }
+        if let Some(last) = visible.last().copied() {
+            self.selected = last;
+        }
+    }
+
+    fn selected_progress(&self) -> (usize, usize) {
+        let visible = self.visible_field_indices();
+        if visible.is_empty() {
+            return (1, 1);
+        }
+        let current = visible
+            .iter()
+            .position(|idx| *idx == self.selected)
+            .map(|v| v + 1)
+            .unwrap_or(1);
+        (current, visible.len())
     }
 
     fn is_field_required(&self, field: &Field) -> bool {
@@ -1103,12 +1218,13 @@ impl SetupApp {
                 }
             }
         }
+        self.ensure_selected_visible();
     }
 
     fn default_value_for_field(&self, key: &str) -> String {
         let provider = self.field_value("LLM_PROVIDER");
         match key {
-            "ENABLED_CHANNELS" => String::new(),
+            "ENABLED_CHANNELS" => "web".into(),
             "TELEGRAM_BOT_TOKEN" | "BOT_USERNAME" | "DISCORD_BOT_TOKEN" | "LLM_API_KEY" => {
                 String::new()
             }
@@ -1211,8 +1327,7 @@ impl SetupApp {
     }
 
     fn progress_bar(&self, width: usize) -> String {
-        let total = self.fields.len().max(1);
-        let done = self.selected + 1;
+        let (done, total) = self.selected_progress();
         let fill = (done * width) / total;
         let mut s = String::new();
         for i in 0..width {
@@ -1436,7 +1551,7 @@ fn save_config_yaml(
 
     let enabled_raw = get("ENABLED_CHANNELS");
     let valid_channel_names: Vec<&str> = {
-        let mut v = vec!["telegram", "discord"];
+        let mut v = vec!["web", "telegram", "discord"];
         for ch in DYNAMIC_CHANNELS {
             v.push(ch.name);
         }
@@ -1450,86 +1565,82 @@ fn save_config_yaml(
         }
     }
 
-    let has_tg =
-        !get("TELEGRAM_BOT_TOKEN").trim().is_empty() || !get("BOT_USERNAME").trim().is_empty();
-    let has_discord = !get("DISCORD_BOT_TOKEN").trim().is_empty();
-    // Check which dynamic channels have at least one non-empty field value
-    let dynamic_channel_present: Vec<(&DynamicChannelDef, bool)> = DYNAMIC_CHANNELS
+    let selected_channels = if channels.is_empty() {
+        vec!["web".to_string()]
+    } else {
+        channels.clone()
+    };
+    let channel_selected = |name: &str| selected_channels.iter().any(|c| c == name);
+    let telegram_token = get("TELEGRAM_BOT_TOKEN");
+    let telegram_username = get("BOT_USERNAME");
+    let discord_token = get("DISCORD_BOT_TOKEN");
+
+    let telegram_present =
+        !telegram_token.trim().is_empty() || !telegram_username.trim().is_empty();
+    let discord_present = !discord_token.trim().is_empty();
+    // Use presence keys so optional defaults (e.g. feishu.domain = "feishu")
+    // do not create disabled channel blocks unexpectedly.
+    let dynamic_channel_include: Vec<(&DynamicChannelDef, bool)> = DYNAMIC_CHANNELS
         .iter()
         .map(|ch| {
-            let present = ch.fields.iter().any(|f| {
-                let key = dynamic_field_key(ch.name, f.yaml_key);
+            let selected = channel_selected(ch.name);
+            let has_presence = ch.presence_keys.iter().any(|yaml_key| {
+                let key = dynamic_field_key(ch.name, yaml_key);
                 !get(&key).trim().is_empty()
             });
-            (ch, present)
+            (ch, selected || has_presence)
         })
         .collect();
 
     let mut yaml = String::new();
     yaml.push_str("# MicroClaw configuration\n\n");
-    yaml.push_str("# Enabled channels (telegram,discord,web)\n");
-    let channels_note = if channels.is_empty() {
-        let mut inferred = Vec::new();
-        if has_tg {
-            inferred.push("telegram");
-        }
-        if has_discord {
-            inferred.push("discord");
-        }
-        for (ch, present) in &dynamic_channel_present {
-            if *present {
-                inferred.push(ch.name);
-            }
-        }
-        if inferred.is_empty() {
-            "setup later".to_string()
-        } else {
-            format!("inferred: {}", inferred.join(","))
-        }
-    } else {
-        channels.join(",")
-    };
-    yaml.push_str(&format!("# channels: {}\n\n", channels_note));
+    yaml.push_str(
+        "# Channel settings (set `enabled: false` to keep credentials without activating the channel)\n",
+    );
+    yaml.push_str("# setup wizard default: web when no channels are selected\n");
+    yaml.push_str("channels:\n");
 
-    yaml.push_str("# Telegram bot token from @BotFather\n");
-    yaml.push_str(&format!(
-        "telegram_bot_token: \"{}\"\n",
-        get("TELEGRAM_BOT_TOKEN")
-    ));
-    yaml.push_str("# Bot username without @\n");
-    yaml.push_str(&format!("bot_username: \"{}\"\n\n", get("BOT_USERNAME")));
+    yaml.push_str("  web:\n");
+    yaml.push_str(&format!("    enabled: {}\n", channel_selected("web")));
 
-    yaml.push_str("# Discord bot token\n");
-    let discord_token = get("DISCORD_BOT_TOKEN");
-    if discord_token.trim().is_empty() {
-        yaml.push_str("discord_bot_token: null\n\n");
-    } else {
-        yaml.push_str(&format!("discord_bot_token: \"{}\"\n\n", discord_token));
+    if channel_selected("telegram") || telegram_present {
+        yaml.push_str("  telegram:\n");
+        yaml.push_str(&format!("    enabled: {}\n", channel_selected("telegram")));
+        if !telegram_token.trim().is_empty() {
+            yaml.push_str(&format!("    bot_token: \"{}\"\n", telegram_token));
+        }
+        if !telegram_username.trim().is_empty() {
+            yaml.push_str(&format!("    bot_username: \"{}\"\n", telegram_username));
+        }
+    }
+    if channel_selected("discord") || discord_present {
+        yaml.push_str("  discord:\n");
+        yaml.push_str(&format!("    enabled: {}\n", channel_selected("discord")));
+        if !discord_token.trim().is_empty() {
+            yaml.push_str(&format!("    bot_token: \"{}\"\n", discord_token));
+        }
     }
 
-    yaml.push_str("web_enabled: true\n\n");
-
-    // Channels section (dynamic channels: Slack, Feishu, etc.)
-    let any_dynamic = dynamic_channel_present.iter().any(|(_, present)| *present);
-    if any_dynamic {
-        yaml.push_str("channels:\n");
-        for (ch, present) in &dynamic_channel_present {
-            if !present {
+    for (ch, include) in &dynamic_channel_include {
+        if !include {
+            continue;
+        }
+        yaml.push_str(&format!("  {}:\n", ch.name));
+        yaml.push_str(&format!("    enabled: {}\n", channel_selected(ch.name)));
+        for f in ch.fields {
+            let key = dynamic_field_key(ch.name, f.yaml_key);
+            let val = get(&key);
+            if val.trim().is_empty() {
                 continue;
             }
-            yaml.push_str(&format!("  {}:\n", ch.name));
-            for f in ch.fields {
-                let key = dynamic_field_key(ch.name, f.yaml_key);
-                let val = get(&key);
-                // Skip optional fields that match the default value
-                if !f.required && val == f.default && !val.is_empty() {
-                    continue;
-                }
-                yaml.push_str(&format!("    {}: \"{}\"\n", f.yaml_key, val));
+            // Skip optional fields that match the default value.
+            if !f.required && val == f.default && !val.is_empty() {
+                continue;
             }
+            yaml.push_str(&format!("    {}: \"{}\"\n", f.yaml_key, val));
         }
-        yaml.push('\n');
     }
+    yaml.push('\n');
 
     yaml.push_str(
         "# LLM provider (anthropic, openai-codex, ollama, openai, openrouter, deepseek, google, etc.)\n",
@@ -1687,6 +1798,7 @@ fn draw_ui(frame: &mut ratatui::Frame<'_>, app: &SetupApp) {
         ])
         .split(frame.area());
 
+    let (selected_visible, visible_total) = app.selected_progress();
     let header = Paragraph::new(vec![
         Line::from(Span::styled(
             "MicroClaw • Interactive Setup",
@@ -1698,8 +1810,8 @@ fn draw_ui(frame: &mut ratatui::Frame<'_>, app: &SetupApp) {
             Span::styled(
                 format!(
                     "Field {}/{}  ·  Section: {}  ·  ",
-                    app.selected + 1,
-                    app.fields.len(),
+                    selected_visible,
+                    visible_total,
                     app.current_section()
                 ),
                 Style::default().fg(Color::DarkGray),
@@ -1717,7 +1829,9 @@ fn draw_ui(frame: &mut ratatui::Frame<'_>, app: &SetupApp) {
 
     let mut lines = Vec::<Line>::new();
     let mut last_section = "";
-    for (i, f) in app.fields.iter().enumerate() {
+    let visible_indices = app.visible_field_indices();
+    for i in visible_indices {
+        let f = &app.fields[i];
         let section = SetupApp::section_for_key(&f.key);
         if section != last_section {
             if !lines.is_empty() {
@@ -1961,6 +2075,7 @@ fn run_wizard(mut terminal: DefaultTerminal) -> Result<bool, MicroClawError> {
     let mut app = SetupApp::new();
 
     loop {
+        app.ensure_selected_visible();
         terminal.draw(|f| draw_ui(f, &app))?;
         if event::poll(Duration::from_millis(250))? {
             let Event::Key(key) = event::read()? else {
@@ -2110,6 +2225,18 @@ mod tests {
     }
 
     #[test]
+    fn test_channel_options_include_web() {
+        let options = SetupApp::channel_options();
+        assert!(options.contains(&"web"));
+    }
+
+    #[test]
+    fn test_setup_defaults_enabled_channels_to_web() {
+        let app = SetupApp::new();
+        assert_eq!(app.default_value_for_field("ENABLED_CHANNELS"), "web");
+    }
+
+    #[test]
     fn test_save_config_yaml() {
         let yaml_path = std::env::temp_dir().join(format!(
             "microclaw_setup_test_{}.yaml",
@@ -2127,8 +2254,13 @@ mod tests {
         assert!(backup.is_none()); // No previous file to back up
 
         let s = fs::read_to_string(&yaml_path).unwrap();
-        assert!(s.contains("telegram_bot_token: \"new_tok\""));
-        assert!(s.contains("bot_username: \"new_bot\""));
+        assert!(s.contains("\nchannels:\n"));
+        assert!(s.contains("  telegram:\n"));
+        assert!(s.contains("    enabled: true\n"));
+        assert!(s.contains("    bot_token: \"new_tok\"\n"));
+        assert!(s.contains("    bot_username: \"new_bot\"\n"));
+        assert!(s.contains("  web:\n"));
+        assert!(s.contains("    enabled: true\n"));
         assert!(s.contains("llm_provider: \"anthropic\""));
         assert!(s.contains("api_key: \"key\""));
 
@@ -2153,7 +2285,172 @@ mod tests {
 
         save_config_yaml(&yaml_path, &values).unwrap();
         let s = fs::read_to_string(&yaml_path).unwrap();
-        assert!(s.contains("discord_bot_token: \"discord_token_123\""));
+        assert!(s.contains("\nchannels:\n"));
+        assert!(s.contains("  discord:\n"));
+        assert!(s.contains("    enabled: false\n"));
+        assert!(s.contains("    bot_token: \"discord_token_123\"\n"));
+        assert!(s.contains("  web:\n"));
+        assert!(s.contains("    enabled: true\n"));
+
+        let _ = fs::remove_file(&yaml_path);
+    }
+
+    #[test]
+    fn test_save_config_yaml_disables_web_when_not_selected() {
+        let yaml_path = std::env::temp_dir().join(format!(
+            "microclaw_setup_web_toggle_test_{}.yaml",
+            Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ));
+
+        let mut values = HashMap::new();
+        values.insert("ENABLED_CHANNELS".into(), "discord".into());
+        values.insert("DISCORD_BOT_TOKEN".into(), "discord_token_123".into());
+        values.insert("LLM_PROVIDER".into(), "anthropic".into());
+        values.insert("LLM_API_KEY".into(), "key".into());
+
+        save_config_yaml(&yaml_path, &values).unwrap();
+        let s = fs::read_to_string(&yaml_path).unwrap();
+        assert!(s.contains("\nchannels:\n"));
+        assert!(s.contains("  discord:\n"));
+        assert!(s.contains("    enabled: true\n"));
+        assert!(s.contains("  web:\n"));
+        assert!(s.contains("    enabled: false\n"));
+
+        let _ = fs::remove_file(&yaml_path);
+    }
+
+    #[test]
+    fn test_save_config_yaml_keeps_telegram_disabled_with_credentials() {
+        let yaml_path = std::env::temp_dir().join(format!(
+            "microclaw_setup_telegram_disabled_test_{}.yaml",
+            Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ));
+
+        let mut values = HashMap::new();
+        values.insert("ENABLED_CHANNELS".into(), "discord".into());
+        values.insert("TELEGRAM_BOT_TOKEN".into(), "tg_token_123".into());
+        values.insert("BOT_USERNAME".into(), "tg_bot".into());
+        values.insert("DISCORD_BOT_TOKEN".into(), "discord_token_123".into());
+        values.insert("LLM_PROVIDER".into(), "anthropic".into());
+        values.insert("LLM_API_KEY".into(), "key".into());
+
+        save_config_yaml(&yaml_path, &values).unwrap();
+        let s = fs::read_to_string(&yaml_path).unwrap();
+        assert!(s.contains("  telegram:\n"));
+        assert!(s.contains("    enabled: false\n"));
+        assert!(s.contains("    bot_token: \"tg_token_123\"\n"));
+        assert!(s.contains("    bot_username: \"tg_bot\"\n"));
+
+        let _ = fs::remove_file(&yaml_path);
+    }
+
+    #[test]
+    fn test_channel_dependent_fields_are_hidden_until_enabled() {
+        let mut app = SetupApp::new();
+        if let Some(field) = app.fields.iter_mut().find(|f| f.key == "ENABLED_CHANNELS") {
+            field.value.clear();
+        }
+        app.ensure_selected_visible();
+
+        let visible_keys: Vec<String> = app
+            .visible_field_indices()
+            .iter()
+            .map(|idx| app.fields[*idx].key.clone())
+            .collect();
+        let hidden_keys = vec![
+            "TELEGRAM_BOT_TOKEN".to_string(),
+            "BOT_USERNAME".to_string(),
+            "DISCORD_BOT_TOKEN".to_string(),
+            dynamic_field_key("feishu", "app_id"),
+            dynamic_field_key("feishu", "app_secret"),
+            dynamic_field_key("feishu", "domain"),
+        ];
+        for key in hidden_keys {
+            assert!(
+                !visible_keys.iter().any(|k| k == &key),
+                "{key} should be hidden when channel is not enabled"
+            );
+        }
+
+        if let Some(field) = app.fields.iter_mut().find(|f| f.key == "ENABLED_CHANNELS") {
+            field.value = "telegram,feishu".to_string();
+        }
+        app.ensure_selected_visible();
+        let visible_keys: Vec<String> = app
+            .visible_field_indices()
+            .iter()
+            .map(|idx| app.fields[*idx].key.clone())
+            .collect();
+        let shown_keys = vec![
+            "TELEGRAM_BOT_TOKEN".to_string(),
+            "BOT_USERNAME".to_string(),
+            dynamic_field_key("feishu", "app_id"),
+            dynamic_field_key("feishu", "app_secret"),
+            dynamic_field_key("feishu", "domain"),
+        ];
+        for key in shown_keys {
+            assert!(
+                visible_keys.iter().any(|k| k == &key),
+                "{key} should be visible when channel is enabled"
+            );
+        }
+    }
+
+    #[test]
+    fn test_save_config_yaml_keeps_dynamic_channel_disabled_when_not_selected() {
+        let yaml_path = std::env::temp_dir().join(format!(
+            "microclaw_setup_dynamic_skip_test_{}.yaml",
+            Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ));
+
+        let mut values = HashMap::new();
+        values.insert("ENABLED_CHANNELS".into(), "".into());
+        values.insert(dynamic_field_key("feishu", "app_id"), "app_id_1".into());
+        values.insert(
+            dynamic_field_key("feishu", "app_secret"),
+            "app_secret_1".into(),
+        );
+        values.insert(dynamic_field_key("feishu", "domain"), "feishu".into());
+        values.insert("LLM_PROVIDER".into(), "anthropic".into());
+        values.insert("LLM_API_KEY".into(), "key".into());
+
+        save_config_yaml(&yaml_path, &values).unwrap();
+        let s = fs::read_to_string(&yaml_path).unwrap();
+        assert!(s.contains("\nchannels:\n"));
+        assert!(s.contains("  feishu:\n"));
+        assert!(s.contains("    enabled: false\n"));
+        assert!(s.contains("    app_id: \"app_id_1\""));
+        assert!(s.contains("    app_secret: \"app_secret_1\""));
+
+        let _ = fs::remove_file(&yaml_path);
+    }
+
+    #[test]
+    fn test_save_config_yaml_includes_dynamic_channel_when_selected() {
+        let yaml_path = std::env::temp_dir().join(format!(
+            "microclaw_setup_dynamic_include_test_{}.yaml",
+            Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ));
+
+        let mut values = HashMap::new();
+        values.insert("ENABLED_CHANNELS".into(), "feishu".into());
+        values.insert(dynamic_field_key("feishu", "app_id"), "app_id_1".into());
+        values.insert(
+            dynamic_field_key("feishu", "app_secret"),
+            "app_secret_1".into(),
+        );
+        values.insert(dynamic_field_key("feishu", "domain"), "feishu".into());
+        values.insert("LLM_PROVIDER".into(), "anthropic".into());
+        values.insert("LLM_API_KEY".into(), "key".into());
+
+        save_config_yaml(&yaml_path, &values).unwrap();
+        let s = fs::read_to_string(&yaml_path).unwrap();
+        assert!(s.contains("\nchannels:\n"));
+        assert!(s.contains("  feishu:\n"));
+        assert!(s.contains("    enabled: true\n"));
+        assert!(s.contains("    app_id: \"app_id_1\""));
+        assert!(s.contains("    app_secret: \"app_secret_1\""));
+        assert!(!s.contains("    domain: \"feishu\""));
 
         let _ = fs::remove_file(&yaml_path);
     }


### PR DESCRIPTION
## Summary
  This PR fixes setup channel handling by making channel enablement explicit via `channels.<name>.enabled`, and by generating channel-first YAML.

  It also fixes the original issue: `microclaw setup` could treat Feishu as “present” when only default `domain: feishu` existed, which incorrectly wrote a `channels.feishu`  block even when Feishu was not selected.

  ## Problems
  - Feishu could be auto-included because dynamic channel presence was inferred from any non-empty field, including optional defaults.
  - `web` was missing from `Enabled channels` choices.
  - Setup output used commented channel hints instead of an active `channels:` key.
  - Deselecting a channel after filling credentials could still be inferred as selected on next setup.
  - `web_enabled` and channel selection duplicated enablement state.
  - `enabled_channels` as a separate config key was unnecessary.

  ## What Changed
  - Added `web` to channel options and made it the first option.
  - Defaulted setup channel selection to `web` when no channels are selected.
  - TUI now shows channel-dependent fields only when that channel is enabled.
  - Setup now writes real `channels:` YAML with per-channel `enabled` flags.
  - Credentials are preserved under each channel even when `enabled: false`.
  - Dynamic channel inclusion now uses channel `presence_keys`; optional defaults like `feishu.domain` no longer force channel presence.
  - Removed duplicated/comment-only channel markers from generated config.
  - Added `Config::channel_enabled()`:
    - Uses `channels.<name>.enabled` when explicitly set.
    - Falls back to legacy inference for backward compatibility.
  - Runtime channel startup now respects `channel_enabled()` for telegram/discord/slack/feishu/web.
  - Updated `microclaw.config.example.yaml` to prioritize nested `channels.*` config with `web` first, while keeping legacy flat fields as compatibility comments.

  ## Behavior After This PR
  - Channel enablement is explicit and stable.
  - Users can keep credentials but disable a channel safely.
  - Re-running setup no longer re-enables channels just because fields are filled.
  - Feishu is no longer auto-included due to default domain value.
  - `web` is visible and first in channel selection.