### PR TITLE
ci: add stability smoke gate with core regression coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,10 +42,22 @@ jobs:
       - run: cargo clippy --all-targets -- -D warnings
       - run: cargo test
 
+  stability-smoke:
+    name: Stability Smoke
+    runs-on: ubuntu-latest
+    needs: [rust-checks]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: scripts/ci/stability_smoke.sh
+
   build:
     name: Build (Release)
     runs-on: ubuntu-latest
-    needs: [web, rust-checks]
+    needs: [web, rust-checks, stability-smoke]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1636,6 +1636,7 @@ dependencies = [
  "tokio",
  "tracing",
  "urlencoding",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/microclaw-tools/Cargo.toml
+++ b/crates/microclaw-tools/Cargo.toml
@@ -14,3 +14,6 @@ serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 urlencoding = "2"
+
+[dev-dependencies]
+uuid = { version = "1", features = ["v4"] }

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -35,3 +35,13 @@ If a hook times out or crashes, runtime skips the hook and continues.
 - If points are missing under burst traffic, raise `otlp_queue_capacity` and review retry settings.
 
 If history is empty, generate traffic first and re-check.
+
+## Stability Gate
+
+- Run stability smoke suite locally: `scripts/ci/stability_smoke.sh`
+- CI gate: `Stability Smoke` job in `.github/workflows/ci.yml`
+- Scope:
+  - cross-chat permissions
+  - scheduler restart persistence
+  - sandbox fallback and require-runtime fail-closed behavior
+  - web inflight and rate-limit regression

--- a/scripts/ci/stability_smoke.sh
+++ b/scripts/ci/stability_smoke.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[stability-smoke] cross-chat permission matrix"
+cargo test --quiet --test tool_permissions
+
+echo "[stability-smoke] scheduler recoverability (restart persistence)"
+cargo test --quiet --test db_integration test_scheduled_task_persists_across_db_reopen
+
+echo "[stability-smoke] sandbox fallback and fail-closed behavior"
+cargo test --quiet -p microclaw-tools test_router_falls_back_to_host_when_runtime_missing_and_not_required
+cargo test --quiet -p microclaw-tools test_router_fails_closed_when_runtime_required_and_missing
+
+echo "[stability-smoke] web inflight and rate-limit behavior"
+cargo test --quiet test_same_session_concurrency_limited
+cargo test --quiet test_rate_limit_window_recovers
+
+echo "[stability-smoke] completed"


### PR DESCRIPTION
## Summary
- add `scripts/ci/stability_smoke.sh` to run focused stability regressions
- add a dedicated `stability-smoke` CI job and make release build depend on it
- add scheduler restart persistence regression test in `tests/db_integration.rs`
- add deterministic sandbox fallback/fail-closed tests in `microclaw-tools`
- document local stability gate execution in operations runbook

## Validation
- cargo fmt --all --check
- cargo clippy --all-targets -- -D warnings
- cargo test
- scripts/ci/stability_smoke.sh
- node scripts/generate_docs_artifacts.mjs --check --no-website
- npm --prefix web run build
