### PR TITLE
metrics: add SLO summary contract for stability tracking

### DIFF
--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -45,3 +45,16 @@ If history is empty, generate traffic first and re-check.
   - scheduler restart persistence
   - sandbox fallback and require-runtime fail-closed behavior
   - web inflight and rate-limit regression
+
+## SLO Alerts
+
+- Query SLO summary: `GET /api/metrics/summary`
+- Request success burn alert: `slo.request_success_rate.value < 0.99`
+- Latency burn alert: `slo.e2e_latency_p95_ms.value > 10000`
+- Tool reliability burn alert: `slo.tool_reliability.value < 0.97`
+- Scheduler recoverability alert: `slo.scheduler_recoverability_7d.value < 0.999`
+
+When any burn alert is active:
+- freeze non-critical feature merges
+- triage and assign incident owner
+- if user-facing impact continues, prepare rollback/hotfix path per stability plan

--- a/src/web/metrics.rs
+++ b/src/web/metrics.rs
@@ -14,10 +14,15 @@ pub(super) async fn api_metrics(
         "ok": true,
         "metrics": {
             "http_requests": snapshot.http_requests,
+            "request_ok": snapshot.request_ok,
+            "request_error": snapshot.request_error,
             "llm_completions": snapshot.llm_completions,
             "llm_input_tokens": snapshot.llm_input_tokens,
             "llm_output_tokens": snapshot.llm_output_tokens,
             "tool_executions": snapshot.tool_executions,
+            "tool_success": snapshot.tool_success,
+            "tool_error": snapshot.tool_error,
+            "tool_policy_blocks": snapshot.tool_policy_blocks,
             "mcp_calls": snapshot.mcp_calls,
             "active_sessions": active_sessions
         }
@@ -28,7 +33,86 @@ pub(super) async fn api_metrics_summary(
     headers: HeaderMap,
     State(state): State<WebState>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    api_metrics(headers, State(state)).await
+    metrics_http_inc(&state).await;
+    require_scope(&state, &headers, AuthScope::Read).await?;
+    persist_metrics_snapshot(&state).await?;
+
+    let snapshot = state.metrics.lock().await.clone();
+    let active_sessions = state.request_hub.sessions.lock().await.len() as i64;
+    let request_total = snapshot.request_ok + snapshot.request_error;
+    let request_success_rate = if request_total > 0 {
+        (snapshot.request_ok as f64) / (request_total as f64)
+    } else {
+        1.0
+    };
+    let request_latency_p95_ms = percentile_p95(&snapshot.request_latency_ms).unwrap_or(0);
+    let tool_total_for_reliability = snapshot.tool_success + snapshot.tool_error;
+    let tool_reliability = if tool_total_for_reliability > 0 {
+        (snapshot.tool_success as f64) / (tool_total_for_reliability as f64)
+    } else {
+        1.0
+    };
+
+    let since_7d = (chrono::Utc::now() - chrono::Duration::days(7)).to_rfc3339();
+    let (scheduler_runs_7d, scheduler_success_7d) =
+        call_blocking(state.app_state.db.clone(), move |db| {
+            db.get_task_run_summary_since(Some(&since_7d))
+        })
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    let scheduler_recoverability = if scheduler_runs_7d > 0 {
+        (scheduler_success_7d as f64) / (scheduler_runs_7d as f64)
+    } else {
+        1.0
+    };
+
+    Ok(Json(json!({
+        "ok": true,
+        "window": "runtime_process",
+        "slo": {
+            "request_success_rate": {
+                "value": request_success_rate,
+                "target": 0.995,
+                "burn_alert": 0.99,
+                "sample_size": request_total
+            },
+            "e2e_latency_p95_ms": {
+                "value": request_latency_p95_ms,
+                "target": 6000,
+                "burn_alert": 10000,
+                "sample_size": snapshot.request_latency_ms.len()
+            },
+            "tool_reliability": {
+                "value": tool_reliability,
+                "target": 0.985,
+                "burn_alert": 0.97,
+                "success": snapshot.tool_success,
+                "error": snapshot.tool_error,
+                "policy_block_excluded": snapshot.tool_policy_blocks
+            },
+            "scheduler_recoverability_7d": {
+                "value": scheduler_recoverability,
+                "target": 1.0,
+                "burn_alert": 0.999,
+                "runs_7d": scheduler_runs_7d,
+                "success_7d": scheduler_success_7d
+            }
+        },
+        "metrics": {
+            "http_requests": snapshot.http_requests,
+            "request_ok": snapshot.request_ok,
+            "request_error": snapshot.request_error,
+            "llm_completions": snapshot.llm_completions,
+            "llm_input_tokens": snapshot.llm_input_tokens,
+            "llm_output_tokens": snapshot.llm_output_tokens,
+            "tool_executions": snapshot.tool_executions,
+            "tool_success": snapshot.tool_success,
+            "tool_error": snapshot.tool_error,
+            "tool_policy_blocks": snapshot.tool_policy_blocks,
+            "mcp_calls": snapshot.mcp_calls,
+            "active_sessions": active_sessions
+        }
+    })))
 }
 
 pub(super) async fn api_metrics_history(


### PR DESCRIPTION
## Summary
- implement `/api/metrics/summary` as an explicit SLO contract endpoint
- add runtime request success/latency counters and p95 computation
- add tool reliability counters with policy blocks excluded from denominator
- add scheduler run summary query (7d) for recoverability signal
- update metrics and runbook docs with thresholds and query semantics
- extend web/db tests for summary and scheduler run aggregation

## Validation
- cargo fmt --all
- cargo clippy --all-targets -- -D warnings
- cargo test
- node scripts/generate_docs_artifacts.mjs --check --no-website
- npm --prefix web run build
