### PR TITLE
feat: add MCP server bulkhead isolation and rate limits

### DIFF
--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -58,3 +58,30 @@ When any burn alert is active:
 - freeze non-critical feature merges
 - triage and assign incident owner
 - if user-facing impact continues, prepare rollback/hotfix path per stability plan
+
+## MCP Server Guardrails
+
+- `mcp.json` supports server-level isolation controls:
+  - `max_concurrent_requests` (default `4`)
+  - `queue_wait_ms` (default `200`)
+  - `rate_limit_per_minute` (default `120`)
+
+Example:
+
+```json
+{
+  "mcpServers": {
+    "remote": {
+      "transport": "streamable_http",
+      "endpoint": "http://127.0.0.1:8080/mcp",
+      "max_concurrent_requests": 4,
+      "queue_wait_ms": 200,
+      "rate_limit_per_minute": 120
+    }
+  }
+}
+```
+
+Behavior:
+- requests are fail-fast when queue wait budget is exceeded.
+- per-server rate limit enforces a fixed 60s window budget.

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -5,7 +5,7 @@ use std::time::{Duration, Instant};
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, Command};
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, Semaphore};
 use tracing::{error, info, warn};
 
 const DEFAULT_PROTOCOL_VERSION: &str = "2025-11-05";
@@ -13,6 +13,9 @@ const DEFAULT_REQUEST_TIMEOUT_SECS: u64 = 120;
 const DEFAULT_MAX_RETRIES: u32 = 2;
 const DEFAULT_HEALTH_INTERVAL_SECS: u64 = 60;
 const TOOLS_CACHE_TTL_SECS: u64 = 300;
+const DEFAULT_MAX_CONCURRENT_REQUESTS: u32 = 4;
+const DEFAULT_QUEUE_WAIT_MS: u64 = 200;
+const DEFAULT_RATE_LIMIT_PER_MINUTE: u32 = 120;
 
 // --- JSON-RPC 2.0 types ---
 
@@ -60,6 +63,12 @@ pub struct McpServerConfig {
     pub max_retries: Option<u32>,
     #[serde(default)]
     pub health_interval_secs: Option<u64>,
+    #[serde(default, alias = "maxConcurrentRequests")]
+    pub max_concurrent_requests: Option<u32>,
+    #[serde(default, alias = "queueWaitMs")]
+    pub queue_wait_ms: Option<u64>,
+    #[serde(default, alias = "rateLimitPerMinute")]
+    pub rate_limit_per_minute: Option<u32>,
 
     // stdio transport
     #[serde(default)]
@@ -120,6 +129,43 @@ enum McpTransport {
     StreamableHttp(Box<Mutex<McpHttpInner>>),
 }
 
+#[derive(Debug)]
+struct FixedWindowRateLimiter {
+    limit_per_minute: u32,
+    window_started_at: Instant,
+    used_in_window: u32,
+}
+
+impl FixedWindowRateLimiter {
+    fn new(limit_per_minute: u32) -> Self {
+        Self {
+            limit_per_minute,
+            window_started_at: Instant::now(),
+            used_in_window: 0,
+        }
+    }
+
+    fn consume_or_retry_after_secs(&mut self, now: Instant) -> Result<(), u64> {
+        if self.limit_per_minute == 0 {
+            return Ok(());
+        }
+        let window = Duration::from_secs(60);
+        if now.duration_since(self.window_started_at) >= window {
+            self.window_started_at = now;
+            self.used_in_window = 0;
+        }
+        if self.used_in_window < self.limit_per_minute {
+            self.used_in_window = self.used_in_window.saturating_add(1);
+            return Ok(());
+        }
+        let retry_after = window
+            .saturating_sub(now.duration_since(self.window_started_at))
+            .as_secs()
+            .max(1);
+        Err(retry_after)
+    }
+}
+
 pub struct McpServer {
     name: String,
     requested_protocol: String,
@@ -130,6 +176,9 @@ pub struct McpServer {
     stdio_spawn: Option<McpStdioSpawnSpec>,
     tools_cache: StdMutex<Vec<McpToolInfo>>,
     tools_cache_updated_at: StdMutex<Option<Instant>>,
+    inflight_limiter: Arc<Semaphore>,
+    queue_wait: Duration,
+    rate_limiter: StdMutex<FixedWindowRateLimiter>,
 }
 
 /// Resolve a command name to its full path. On Windows, also checks for
@@ -220,6 +269,15 @@ impl McpServer {
                 .unwrap_or(DEFAULT_REQUEST_TIMEOUT_SECS),
         );
         let max_retries = config.max_retries.unwrap_or(DEFAULT_MAX_RETRIES);
+        let max_concurrent_requests = config
+            .max_concurrent_requests
+            .unwrap_or(DEFAULT_MAX_CONCURRENT_REQUESTS)
+            .max(1);
+        let queue_wait =
+            Duration::from_millis(config.queue_wait_ms.unwrap_or(DEFAULT_QUEUE_WAIT_MS).max(1));
+        let rate_limit_per_minute = config
+            .rate_limit_per_minute
+            .unwrap_or(DEFAULT_RATE_LIMIT_PER_MINUTE);
         let transport_name = config.transport.trim().to_ascii_lowercase();
 
         let (transport, stdio_spawn) = match transport_name.as_str() {
@@ -276,6 +334,9 @@ impl McpServer {
             stdio_spawn,
             tools_cache: StdMutex::new(Vec::new()),
             tools_cache_updated_at: StdMutex::new(None),
+            inflight_limiter: Arc::new(Semaphore::new(max_concurrent_requests as usize)),
+            queue_wait,
+            rate_limiter: StdMutex::new(FixedWindowRateLimiter::new(rate_limit_per_minute)),
         };
 
         server.initialize_connection().await?;
@@ -567,9 +628,17 @@ impl McpServer {
             }
         };
 
-        let mut inner = inner.lock().await;
-        let id = inner.next_id;
-        inner.next_id += 1;
+        let (id, client, endpoint, headers) = {
+            let mut inner = inner.lock().await;
+            let id = inner.next_id;
+            inner.next_id += 1;
+            (
+                id,
+                inner.client.clone(),
+                inner.endpoint.clone(),
+                inner.headers.clone(),
+            )
+        };
 
         let request = JsonRpcRequest {
             jsonrpc: "2.0".to_string(),
@@ -578,8 +647,8 @@ impl McpServer {
             params,
         };
 
-        let mut req = inner.client.post(&inner.endpoint).json(&request);
-        for (k, v) in &inner.headers {
+        let mut req = client.post(endpoint).json(&request);
+        for (k, v) in &headers {
             req = req.header(k, v);
         }
 
@@ -616,10 +685,51 @@ impl McpServer {
         method: &str,
         params: Option<serde_json::Value>,
     ) -> Result<serde_json::Value, String> {
-        match &self.transport {
-            McpTransport::Stdio(_) => self.send_request_stdio_with_retries(method, params).await,
-            McpTransport::StreamableHttp(_) => self.send_request_http(method, params).await,
+        {
+            let mut rate = self.rate_limiter.lock().unwrap_or_else(|e| e.into_inner());
+            if let Err(retry_after_secs) = rate.consume_or_retry_after_secs(Instant::now()) {
+                return Err(format!(
+                    "MCP server '{}' rate-limited; retry in ~{}s",
+                    self.name, retry_after_secs
+                ));
+            }
         }
+
+        let permit = tokio::time::timeout(
+            self.queue_wait,
+            self.inflight_limiter.clone().acquire_owned(),
+        )
+        .await
+        .map_err(|_| {
+            format!(
+                "MCP server '{}' busy; exceeded queue wait of {:?}",
+                self.name, self.queue_wait
+            )
+        })?
+        .map_err(|_| format!("MCP server '{}' limiter is closed", self.name))?;
+
+        match &self.transport {
+            McpTransport::Stdio(_) => {
+                Self::send_request_with_permit(
+                    permit,
+                    self.send_request_stdio_with_retries(method, params),
+                )
+                .await
+            }
+            McpTransport::StreamableHttp(_) => {
+                Self::send_request_with_permit(permit, self.send_request_http(method, params)).await
+            }
+        }
+    }
+
+    async fn send_request_with_permit<F>(
+        _permit: tokio::sync::OwnedSemaphorePermit,
+        fut: F,
+    ) -> Result<serde_json::Value, String>
+    where
+        F: std::future::Future<Output = Result<serde_json::Value, String>>,
+    {
+        fut.await
     }
 
     async fn send_notification(
@@ -933,6 +1043,9 @@ mod tests {
         assert_eq!(server.transport, "stdio");
         assert!(server.protocol_version.is_none());
         assert!(server.max_retries.is_none());
+        assert!(server.max_concurrent_requests.is_none());
+        assert!(server.queue_wait_ms.is_none());
+        assert!(server.rate_limit_per_minute.is_none());
     }
 
     #[test]
@@ -964,5 +1077,44 @@ mod tests {
         assert_eq!(remote.endpoint, "http://127.0.0.1:8080/mcp");
         assert_eq!(remote.max_retries, Some(3));
         assert_eq!(remote.health_interval_secs, Some(15));
+    }
+
+    #[test]
+    fn test_mcp_bulkhead_and_rate_limit_parse() {
+        let json = r#"{
+          "mcpServers": {
+            "remote": {
+              "transport": "streamable_http",
+              "endpoint": "http://127.0.0.1:8080/mcp",
+              "max_concurrent_requests": 6,
+              "queue_wait_ms": 500,
+              "rate_limit_per_minute": 240
+            }
+          }
+        }"#;
+
+        let cfg: McpConfig = serde_json::from_str(json).unwrap();
+        let remote = cfg.mcp_servers.get("remote").unwrap();
+        assert_eq!(remote.max_concurrent_requests, Some(6));
+        assert_eq!(remote.queue_wait_ms, Some(500));
+        assert_eq!(remote.rate_limit_per_minute, Some(240));
+    }
+
+    #[test]
+    fn test_rate_limiter_blocks_after_limit() {
+        let mut limiter = FixedWindowRateLimiter::new(2);
+        let now = Instant::now();
+        assert!(limiter.consume_or_retry_after_secs(now).is_ok());
+        assert!(limiter.consume_or_retry_after_secs(now).is_ok());
+        assert!(limiter.consume_or_retry_after_secs(now).is_err());
+    }
+
+    #[test]
+    fn test_rate_limiter_can_be_disabled() {
+        let mut limiter = FixedWindowRateLimiter::new(0);
+        let now = Instant::now();
+        for _ in 0..10 {
+            assert!(limiter.consume_or_retry_after_secs(now).is_ok());
+        }
     }
 }


### PR DESCRIPTION
## Summary

Add per-server MCP bulkhead isolation and rate limiting controls to reduce cascading failures under bursty tool traffic.

## What changed

- New optional `mcp.json` server settings:
  - `max_concurrent_requests` (default `4`)
  - `queue_wait_ms` (default `200`)
  - `rate_limit_per_minute` (default `120`)
- Implemented fixed-window per-server limiter in `src/mcp.rs`.
- Added server-level in-flight semaphore and queue-wait budget.
- Request behavior now fail-fast when:
  - queue wait exceeds configured budget
  - per-minute request budget is exhausted
- Reduced unnecessary serialization for streamable HTTP MCP transport:
  - lock is now used only to allocate request id and clone client config
  - network request runs outside the transport mutex
- Updated runbook with configuration examples and operational behavior.

## Compatibility

- Backward compatible: existing `mcp.json` continues to work unchanged.
- Defaults are applied when new fields are absent.

## Tests

- Added parsing test for new config fields.
- Added rate limiter behavior tests:
  - blocks after limit reached
  - can be disabled (`rate_limit_per_minute = 0`)

## Validation

- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `scripts/ci/stability_smoke.sh`
- `node scripts/generate_docs_artifacts.mjs --check --no-website`
- `node scripts/generate_docs_artifacts.mjs --check`
- `npm --prefix web run build`
- `npm --prefix website run build`
