### PR TITLE
feat: add MCP reliability rejection metrics to summary

### DIFF
--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -19,6 +19,9 @@
 - `tool_error`
 - `tool_policy_blocks` (excluded from tool reliability denominator)
 - `mcp_calls`
+- `mcp_rate_limited_rejections`
+- `mcp_bulkhead_rejections`
+- `mcp_circuit_open_rejections`
 - `active_sessions`
 
 ## SLO Contract (`/api/metrics/summary`)
@@ -55,6 +58,10 @@ Metrics snapshots are persisted to SQLite `metrics_history` by minute bucket:
 - `tool_executions`
 - `mcp_calls`
 - `active_sessions`
+
+Note:
+- MCP rejection counters are currently snapshot-only fields from `GET /api/metrics` and
+  `GET /api/metrics/summary` (not persisted in `metrics_history` yet).
 
 Retention can be configured via:
 

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -36,6 +36,11 @@ If a hook times out or crashes, runtime skips the hook and continues.
 
 If history is empty, generate traffic first and re-check.
 
+MCP reliability counters (snapshot/summary):
+- `mcp_rate_limited_rejections`
+- `mcp_bulkhead_rejections`
+- `mcp_circuit_open_rejections`
+
 ## Stability Gate
 
 - Run stability smoke suite locally: `scripts/ci/stability_smoke.sh`

--- a/src/web.rs
+++ b/src/web.rs
@@ -95,6 +95,9 @@ struct WebMetrics {
     tool_error: i64,
     tool_policy_blocks: i64,
     mcp_calls: i64,
+    mcp_rate_limited_rejections: i64,
+    mcp_bulkhead_rejections: i64,
+    mcp_circuit_open_rejections: i64,
 }
 
 #[derive(Clone, Debug)]
@@ -2096,6 +2099,21 @@ mod tests {
                 .unwrap_or(0)
                 > 0
         );
+        assert!(metrics_json
+            .get("metrics")
+            .and_then(|m| m.get("mcp_rate_limited_rejections"))
+            .and_then(|v| v.as_i64())
+            .is_some());
+        assert!(metrics_json
+            .get("metrics")
+            .and_then(|m| m.get("mcp_bulkhead_rejections"))
+            .and_then(|v| v.as_i64())
+            .is_some());
+        assert!(metrics_json
+            .get("metrics")
+            .and_then(|m| m.get("mcp_circuit_open_rejections"))
+            .and_then(|v| v.as_i64())
+            .is_some());
 
         let history_req = Request::builder()
             .method("GET")

--- a/src/web/metrics.rs
+++ b/src/web/metrics.rs
@@ -24,6 +24,9 @@ pub(super) async fn api_metrics(
             "tool_error": snapshot.tool_error,
             "tool_policy_blocks": snapshot.tool_policy_blocks,
             "mcp_calls": snapshot.mcp_calls,
+            "mcp_rate_limited_rejections": snapshot.mcp_rate_limited_rejections,
+            "mcp_bulkhead_rejections": snapshot.mcp_bulkhead_rejections,
+            "mcp_circuit_open_rejections": snapshot.mcp_circuit_open_rejections,
             "active_sessions": active_sessions
         }
     })))


### PR DESCRIPTION
## Summary

Expose MCP reliability rejection counters in Web metrics summary so operators can see when MCP traffic is being rejected by rate limit, bulkhead, or circuit-breaker style conditions.

## What changed

- MCP tool errors now map to specific `error_type` values:
  - `mcp_rate_limited`
  - `mcp_bulkhead_rejected`
  - `mcp_circuit_open`
  - fallback: `mcp_error`
- Web runtime metrics now track MCP rejection counters:
  - `mcp_rate_limited_rejections`
  - `mcp_bulkhead_rejections`
  - `mcp_circuit_open_rejections`
- Rejection counters increment from tool result events when MCP tools fail with the above error types.
- `GET /api/metrics` and `GET /api/metrics/summary` now include these counters.
- Docs updated:
  - `docs/observability/metrics.md`
  - `docs/operations/runbook.md`

## Notes

- These counters are currently snapshot/summary metrics (not yet persisted in `metrics_history`).

## Tests

- Added unit test for MCP error-type classification.
- Updated metrics endpoint test to assert new fields are present.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `scripts/ci/stability_smoke.sh`
- `node scripts/generate_docs_artifacts.mjs --check --no-website`
- `node scripts/generate_docs_artifacts.mjs --check`
- `npm --prefix web run build`
- `npm --prefix website run build`
