### PR TITLE
feat: add derived MCP reliability fields to metrics summary

### DIFF
--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -3,6 +3,7 @@
 ## Endpoints
 
 - `GET /api/metrics`: current counters/gauges snapshot.
+- `GET /api/metrics/summary`: snapshot plus derived reliability summary.
 - `GET /api/metrics/history?minutes=1440&limit=2000`: persisted timeline from SQLite.
 
 ## Fields
@@ -46,6 +47,10 @@ channels:
 
 - Traffic last 24h: `/api/metrics/history?minutes=1440`
 - High-load short window: `/api/metrics/history?minutes=60&limit=3600`
+
+`/api/metrics/summary` derived fields:
+- `summary.mcp_rejections_total`
+- `summary.mcp_rejection_ratio`
 
 ## OTLP Exporter
 

--- a/src/web.rs
+++ b/src/web.rs
@@ -2063,6 +2063,28 @@ mod tests {
             .and_then(|v| v.as_i64())
             .is_some());
 
+        let summary_req = Request::builder()
+            .method("GET")
+            .uri("/api/metrics/summary")
+            .body(Body::empty())
+            .unwrap();
+        let summary_resp = app.clone().oneshot(summary_req).await.unwrap();
+        assert_eq!(summary_resp.status(), StatusCode::OK);
+        let summary_body = axum::body::to_bytes(summary_resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let summary_json: serde_json::Value = serde_json::from_slice(&summary_body).unwrap();
+        assert!(summary_json
+            .get("summary")
+            .and_then(|m| m.get("mcp_rejections_total"))
+            .and_then(|v| v.as_i64())
+            .is_some());
+        assert!(summary_json
+            .get("summary")
+            .and_then(|m| m.get("mcp_rejection_ratio"))
+            .and_then(|v| v.as_f64())
+            .is_some());
+
         let history_req = Request::builder()
             .method("GET")
             .uri("/api/metrics/history?minutes=60")


### PR DESCRIPTION
## Summary

Add derived MCP reliability fields to `/api/metrics/summary` so dashboards/alerts can consume rejection totals and rejection ratio directly.

This PR is stacked on top of #55.

## What changed

- `/api/metrics/summary` now returns:
  - `summary.mcp_rejections_total`
  - `summary.mcp_rejection_ratio`
- Keeps existing `metrics` snapshot block unchanged.
- Added test coverage in web metrics endpoint test for the new summary fields.
- Updated observability docs to include summary endpoint and derived fields.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `scripts/ci/stability_smoke.sh`
- `node scripts/generate_docs_artifacts.mjs --check --no-website`
- `node scripts/generate_docs_artifacts.mjs --check`
- `npm --prefix web run build`
- `npm --prefix website run build`
