### PR TITLE
feat: export MCP reliability rejection counters to OTLP

### DIFF
--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -52,6 +52,11 @@ channels:
 - `summary.mcp_rejections_total`
 - `summary.mcp_rejection_ratio`
 
+OTLP export includes corresponding counters:
+- `microclaw_mcp_rate_limited_rejections`
+- `microclaw_mcp_bulkhead_rejections`
+- `microclaw_mcp_circuit_open_rejections`
+
 ## OTLP Exporter
 
 Optional OTLP/HTTP protobuf export:

--- a/src/web.rs
+++ b/src/web.rs
@@ -448,6 +448,9 @@ async fn persist_metrics_snapshot(state: &WebState) -> Result<(), (StatusCode, S
             llm_output_tokens: snapshot.llm_output_tokens,
             tool_executions: snapshot.tool_executions,
             mcp_calls: snapshot.mcp_calls,
+            mcp_rate_limited_rejections: snapshot.mcp_rate_limited_rejections,
+            mcp_bulkhead_rejections: snapshot.mcp_bulkhead_rejections,
+            mcp_circuit_open_rejections: snapshot.mcp_circuit_open_rejections,
             active_sessions,
         };
         tokio::spawn(async move {


### PR DESCRIPTION
## Summary

Export MCP reliability rejection counters through OTLP metrics to support external alerting and dashboards.

This PR is stacked on top of #56.

## What changed

- Extended `OtlpMetricSnapshot` with:
  - `mcp_rate_limited_rejections`
  - `mcp_bulkhead_rejections`
  - `mcp_circuit_open_rejections`
- OTLP payload now exports:
  - `microclaw_mcp_rate_limited_rejections`
  - `microclaw_mcp_bulkhead_rejections`
  - `microclaw_mcp_circuit_open_rejections`
- Wired web metrics snapshot -> OTLP exporter for these new counters.
- Updated OTLP unit test to assert new metric names are present.
- Updated observability docs with new OTLP counter names.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `scripts/ci/stability_smoke.sh`
- `node scripts/generate_docs_artifacts.mjs --check --no-website`
- `node scripts/generate_docs_artifacts.mjs --check`
- `npm --prefix web run build`
- `npm --prefix website run build`
