### PR TITLE
chore(docker): add .dockerignore for safer, faster image builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,27 @@
+# VCS and editor metadata
+.git
+.github
+.history
+.DS_Store
+
+# Build outputs and caches
+target
+tmp
+working_dir
+coverage
+
+# Local runtime/state data
+data
+microclaw.data
+microclaw.config.yaml
+microclaw.config.yaml.*
+*.db
+*.sqlite
+*.sqlite3
+
+# JS build dependencies
+web/node_modules
+website/node_modules
+
+# Keep Docker context lean by excluding local docs site outputs
+website


### PR DESCRIPTION
## Summary
- add a top-level `.dockerignore`
- exclude large/sensitive local paths from Docker build context (`target/`, `.git/`, `data/`, local db/config artifacts, node_modules)
- keep required source/runtime paths in context for existing `Dockerfile` flow

## Why
PR #71 added Docker packaging files, but without `.dockerignore` Docker sends the full repo context (including local build/runtime state). On this repo, `target/` alone is multi-GB and significantly slows local/CI builds while increasing accidental context leakage risk.

## Validation
- `cargo test channels::telegram::tests::test_check_private_chat_access -- --nocapture`
- Docker CLI unavailable in current environment, so image build was not executed locally in this run.
