### PR TITLE
improve(docker): harden runtime and align persistent data path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-# Stage 1: Build - Upgraded to 1.88 to meet dependency MSRV requirements
-FROM rust:1.88-slim-bookworm AS builder
+# syntax=docker/dockerfile:1
+
+# Stage 1: Build tools
+FROM rust:1.88-slim-bookworm AS chef
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y \
@@ -11,13 +13,27 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /usr/src/microclaw
 
-# Copy the entire project repository
+# Install cargo-chef to improve dependency layer caching
+RUN cargo install cargo-chef --locked
+
+# Stage 2: Prepare dependency recipe
+FROM chef AS planner
+
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+# Stage 3: Build
+FROM chef AS builder
+
+COPY --from=planner /usr/src/microclaw/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
+
 COPY . .
 
 # Build the binary in release mode
-RUN cargo build --release
+RUN cargo build --release --locked --bin microclaw
 
-# Stage 2: Run
+# Stage 4: Run
 FROM debian:bookworm-slim
 
 # Install runtime certificates and libraries
@@ -26,6 +42,9 @@ RUN apt-get update && apt-get install -y \
     libssl3 \
     libsqlite3-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Run as non-root by default
+RUN useradd --create-home --home-dir /home/microclaw --uid 10001 --shell /usr/sbin/nologin microclaw
 
 WORKDIR /app
 
@@ -37,7 +56,10 @@ COPY --from=builder /usr/src/microclaw/web ./web
 COPY --from=builder /usr/src/microclaw/skills ./skills
 COPY --from=builder /usr/src/microclaw/scripts ./scripts
 
-# Ensure the binary is executable
-RUN chmod +x /usr/local/bin/microclaw
+RUN mkdir -p /home/microclaw/.microclaw /app/tmp \
+    && chown -R microclaw:microclaw /home/microclaw /app
+
+ENV HOME=/home/microclaw
+USER microclaw
 
 CMD ["microclaw"]

--- a/README.md
+++ b/README.md
@@ -674,7 +674,9 @@ All configuration is via `microclaw.config.yaml`:
 | `channels.telegram.default_account` | No | unset | Default Telegram account ID in multi-account mode |
 | `channels.telegram.accounts.<id>.bot_token` | No* | unset | Telegram bot token for a specific account (recommended multi-account mode) |
 | `channels.telegram.accounts.<id>.bot_username` | No | unset | Telegram username for a specific account (without `@`) |
+| `channels.telegram.allowed_user_ids` | No | `[]` | Optional Telegram private chat sender allowlist at channel scope |
 | `channels.telegram.accounts.<id>.allowed_groups` | No | `[]` | Optional Telegram group allowlist scoped to one account |
+| `channels.telegram.accounts.<id>.allowed_user_ids` | No | `[]` | Optional Telegram private chat sender allowlist scoped to one account (overrides channel scope) |
 | `discord_bot_token` | No* | -- | Discord bot token from Discord Developer Portal |
 | `channels.discord.default_account` | No | unset | Default Discord account ID in multi-account mode |
 | `channels.discord.accounts.<id>.bot_token` | No* | unset | Discord bot token for a specific account |

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,14 +7,15 @@ services:
     command: ["microclaw", "start"]
     stdin_open: true
     tty: true
+    init: true
     restart: unless-stopped
     volumes:
-      - ./microclaw.config.yaml:/app/microclaw.config.yaml
-      - ./AGENTS.md:/app/AGENTS.md
-      - ./CLAUDE.md:/app/CLAUDE.md
-      - ./data:/app/data
+      - ./microclaw.config.yaml:/app/microclaw.config.yaml:ro
+      # Default data_dir resolves to ~/.microclaw; persist it on the host.
+      - ./data:/home/microclaw/.microclaw
       - ./tmp:/app/tmp
     environment:
       - RUST_LOG=info
+      - HOME=/home/microclaw
     ports:
       - "127.0.0.1:10961:10961" # Uncomment and adjust if you plan to use MicroClaw's web UI


### PR DESCRIPTION
## Summary
- optimize Docker build caching with `cargo-chef` and `--locked` builds
- run runtime image as non-root user (`microclaw`) with explicit writable directories
- fix `docker-compose` persistence path to match MicroClaw default data root (`~/.microclaw`)
- remove unnecessary root-level file mounts from compose (`AGENTS.md` / `CLAUDE.md`)
- document missing Telegram DM allowlist keys in README config table

## Why
After the previous Docker packaging merge, there were still practical runtime issues:
1. compose mounted `./data` to `/app/data`, but default `data_dir` is `~/.microclaw`, so persisted data could be lost unexpectedly.
2. runtime container ran as root.
3. build layer cache could be improved for iterative image builds.
4. README examples mentioned `allowed_user_ids`, but the config table did not list those keys.

## Validation
- `cargo test channels::telegram::tests::test_build_telegram_runtime_contexts_multi_account -- --nocapture`
- `cargo test channels::telegram::tests::test_check_private_chat_access -- --nocapture`
- `cargo test config::tests::test_default_data_dir_uses_microclaw_home -- --nocapture`
- Docker CLI not available in this execution environment, so image build/runtime smoke test was not run locally here.
