### PR TITLE
[codex] centralize slash command handling and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,8 +301,13 @@ Supported frontmatter fields:
 Unavailable skills are filtered automatically by platform/dependencies, so unsupported skills do not appear in `/skills`.
 
 **Commands:**
+- `/reset` -- clear current chat context (session + chat history)
 - `/skills` -- list all available skills
+- `/reload-skills` -- reload skills from disk
+- `/archive` -- archive current in-memory session as markdown
 - `/usage` -- show token usage summary (current chat + global totals)
+- `/status` -- show provider/model plus current chat session/task status
+- `/model` -- show current provider/model (`/model <name>` currently reports switch is not supported yet)
 
 ## MCP
 
@@ -467,7 +472,10 @@ Recommended BotFather settings (optional but useful):
 - `/setcommands` -- register commands so users see them in the menu:
   ```
   reset - Clear current session
+  status - Show runtime/session status
+  model - Show current provider/model
   skills - List available agent skills
+  usage - Show usage summary
   ```
 - `/setprivacy` -- set to `Disable` if you want the bot to see all group messages (not just @mentions)
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -277,8 +277,13 @@ MicroClaw 支持 [Anthropic Agent Skills](https://github.com/anthropics/skills) 
 **添加技能：** 在 `<data_dir>/skills/` 下创建子目录，放入包含 YAML frontmatter（`name` 和 `description`）和 markdown 指令的 `SKILL.md` 文件。
 
 **命令：**
+- `/reset` -- 清除当前聊天上下文（会话 + 聊天历史）
 - `/skills` -- 列出所有可用技能
+- `/reload-skills` -- 从磁盘重新加载技能
+- `/archive` -- 将当前内存会话归档为 markdown
 - `/usage` -- 查看 token 用量统计（当前聊天 + 全局汇总）
+- `/status` -- 查看 provider/model 和当前聊天会话/任务状态
+- `/model` -- 查看当前 provider/model（`/model <name>` 目前会提示暂不支持切换）
 
 ## MCP
 
@@ -383,7 +388,10 @@ Telegram（可选）：
 - `/setcommands` -- 注册命令，用户可以在菜单中看到：
   ```
   reset - 清除当前会话
+  status - 查看运行/会话状态
+  model - 查看当前 provider/model
   skills - 查看可用技能列表
+  usage - 查看用量统计
   ```
 - `/setprivacy` -- 设置为 `Disable`，这样机器人可以看到群里所有消息（而不仅仅是 @提及）
 

--- a/src/channels/discord.rs
+++ b/src/channels/discord.rs
@@ -12,19 +12,16 @@ use serenity::model::id::ChannelId;
 use serenity::prelude::*;
 use tracing::{error, info, warn};
 
-use crate::agent_engine::archive_conversation;
 use crate::agent_engine::process_with_agent_with_events;
 use crate::agent_engine::AgentEvent;
 use crate::agent_engine::AgentRequestContext;
-use crate::chat_commands::{build_model_response, build_status_response};
+use crate::chat_commands::handle_chat_command;
 use crate::runtime::AppState;
 use microclaw_channels::channel::ConversationKind;
 use microclaw_channels::channel_adapter::ChannelAdapter;
-use microclaw_core::llm_types::Message as LlmMessage;
 use microclaw_core::text::{floor_char_boundary, split_text};
 use microclaw_storage::db::call_blocking;
 use microclaw_storage::db::StoredMessage;
-use microclaw_storage::usage::build_usage_report;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct DiscordAccountConfig {
@@ -348,105 +345,18 @@ impl EventHandler for Handler {
             return;
         }
 
-        // Handle /reset command
-        if text.trim() == "/reset" {
-            let _ = call_blocking(self.app_state.db.clone(), move |db| {
-                db.clear_chat_context(channel_id)
-            })
-            .await;
-            let _ = msg
-                .channel_id
-                .say(&ctx.http, "Context cleared (session + chat history).")
-                .await;
-            return;
-        }
-
-        // Handle /skills command
-        if text.trim() == "/skills" {
-            let formatted = self.app_state.skills.list_skills_formatted();
-            let _ = msg.channel_id.say(&ctx.http, &formatted).await;
-            return;
-        }
-
-        // Handle /reload-skills command
-        if text.trim() == "/reload-skills" {
-            let reloaded = self.app_state.skills.reload();
-            let count = reloaded.len();
-            let _ = msg
-                .channel_id
-                .say(&ctx.http, format!("Reloaded {} skills from disk.", count))
-                .await;
-            return;
-        }
-
-        // Handle /archive command
-        if text.trim() == "/archive" {
-            if let Ok(Some((json, _))) = call_blocking(self.app_state.db.clone(), move |db| {
-                db.load_session(channel_id)
-            })
-            .await
-            {
-                let messages: Vec<LlmMessage> = serde_json::from_str(&json).unwrap_or_default();
-                if messages.is_empty() {
-                    let _ = msg
-                        .channel_id
-                        .say(&ctx.http, "No session to archive.")
-                        .await;
-                } else {
-                    archive_conversation(
-                        &self.app_state.config.data_dir,
-                        &self.runtime.channel_name,
-                        channel_id,
-                        &messages,
-                    );
-                    let _ = msg
-                        .channel_id
-                        .say(&ctx.http, format!("Archived {} messages.", messages.len()))
-                        .await;
-                }
-            } else {
-                let _ = msg
-                    .channel_id
-                    .say(&ctx.http, "No session to archive.")
-                    .await;
-            }
-            return;
-        }
-
-        // Handle /usage command
-        if text.trim() == "/usage" {
-            match build_usage_report(self.app_state.db.clone(), channel_id).await {
-                Ok(text) => {
-                    let _ = msg.channel_id.say(&ctx.http, text).await;
-                }
-                Err(e) => {
-                    let _ = msg
-                        .channel_id
-                        .say(&ctx.http, format!("Failed to query usage statistics: {e}"))
-                        .await;
-                }
-            }
-            return;
-        }
-
-        // Handle /status command
-        if text.trim() == "/status" {
-            let status = build_status_response(
-                self.app_state.db.clone(),
-                &self.app_state.config,
+        if text.trim_start().starts_with('/') {
+            if let Some(reply) = handle_chat_command(
+                &self.app_state,
                 channel_id,
                 &self.runtime.channel_name,
+                &text,
             )
-            .await;
-            let _ = msg.channel_id.say(&ctx.http, status).await;
-            return;
-        }
-
-        // Handle /model command
-        if text.trim() == "/model" || text.trim_start().starts_with("/model ") {
-            let model_text = build_model_response(&self.app_state.config, &text);
-            let _ = msg.channel_id.say(&ctx.http, model_text).await;
-            return;
+            .await
+            {
+                let _ = msg.channel_id.say(&ctx.http, reply).await;
+                return;
+            }
         }
 
         if text.is_empty() {

--- a/src/channels/feishu.rs
+++ b/src/channels/feishu.rs
@@ -9,15 +9,13 @@ use tokio::sync::RwLock;
 use tokio_tungstenite::tungstenite::Message as WsMessage;
 use tracing::{error, info, warn};
 
-use crate::agent_engine::archive_conversation;
 use crate::agent_engine::process_with_agent_with_events;
 use crate::agent_engine::AgentEvent;
 use crate::agent_engine::AgentRequestContext;
-use crate::chat_commands::{build_model_response, build_status_response};
+use crate::chat_commands::handle_chat_command;
 use crate::runtime::AppState;
 use microclaw_channels::channel::ConversationKind;
 use microclaw_channels::channel_adapter::ChannelAdapter;
-use microclaw_core::llm_types::Message as LlmMessage;
 use microclaw_storage::db::call_blocking;
 use microclaw_storage::db::StoredMessage;
 
@@ -32,7 +30,6 @@ type WsSink = Arc<
     >,
 >;
 use microclaw_core::text::split_text;
-use microclaw_storage::usage::build_usage_report;
 
 // ---------------------------------------------------------------------------
 // Config
@@ -1426,125 +1423,14 @@ async fn handle_feishu_message(
     };
 
     let trimmed = text.trim();
-    if trimmed == "/reset" {
-        let _ = call_blocking(app_state.db.clone(), move |db| {
-            db.clear_chat_context(chat_id)
-        })
-        .await;
-        let _ = send_feishu_response(
-            &http_client,
-            base_url,
-            &token,
-            external_chat_id,
-            "Context cleared (session + chat history).",
-        )
-        .await;
-        return;
-    }
-    if trimmed == "/skills" {
-        let formatted = app_state.skills.list_skills_formatted();
-        let _ = send_feishu_response(&http_client, base_url, &token, external_chat_id, &formatted)
-            .await;
-        return;
-    }
-    if trimmed == "/reload-skills" {
-        let reloaded = app_state.skills.reload();
-        let count = reloaded.len();
-        let _ = send_feishu_response(
-            &http_client,
-            base_url,
-            &token,
-            external_chat_id,
-            &format!("Reloaded {} skills from disk.", count),
-        )
-        .await;
-        return;
-    }
-    if trimmed == "/archive" {
-        if let Ok(Some((json, _))) =
-            call_blocking(app_state.db.clone(), move |db| db.load_session(chat_id)).await
+    if trimmed.starts_with('/') {
+        if let Some(reply) =
+            handle_chat_command(&app_state, chat_id, &runtime.channel_name, trimmed).await
         {
-            let messages: Vec<LlmMessage> = serde_json::from_str(&json).unwrap_or_default();
-            if messages.is_empty() {
-                let _ = send_feishu_response(
-                    &http_client,
-                    base_url,
-                    &token,
-                    external_chat_id,
-                    "No session to archive.",
-                )
+            let _ = send_feishu_response(&http_client, base_url, &token, external_chat_id, &reply)
                 .await;
-            } else {
-                archive_conversation(
-                    &app_state.config.data_dir,
-                    &runtime.channel_name,
-                    chat_id,
-                    &messages,
-                );
-                let _ = send_feishu_response(
-                    &http_client,
-                    base_url,
-                    &token,
-                    external_chat_id,
-                    &format!("Archived {} messages.", messages.len()),
-                )
-                .await;
-            }
-        } else {
-            let _ = send_feishu_response(
-                &http_client,
-                base_url,
-                &token,
-                external_chat_id,
-                "No session to archive.",
-            )
-            .await;
+            return;
         }
-        return;
-    }
-    if trimmed == "/usage" {
-        match build_usage_report(app_state.db.clone(), chat_id).await {
-            Ok(report) => {
-                let _ =
-                    send_feishu_response(&http_client, base_url, &token, external_chat_id, &report)
-                        .await;
-            }
-            Err(e) => {
-                let _ = send_feishu_response(
-                    &http_client,
-                    base_url,
-                    &token,
-                    external_chat_id,
-                    &format!("Failed to query usage statistics: {e}"),
-                )
-                .await;
-            }
-        }
-        return;
-    }
-    if trimmed == "/status" {
-        let status = build_status_response(
-            app_state.db.clone(),
-            &app_state.config,
-            chat_id,
-            &runtime.channel_name,
-        )
-        .await;
-        let _ =
-            send_feishu_response(&http_client, base_url, &token, external_chat_id, &status).await;
-        return;
-    }
-    if trimmed == "/model" || trimmed.starts_with("/model ") {
-        let model_text = build_model_response(&app_state.config, trimmed);
-        let _ = send_feishu_response(
-            &http_client,
-            base_url,
-            &token,
-            external_chat_id,
-            &model_text,
-        )
-        .await;
-        return;
     }
 
     // Determine if we should respond

--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -8,19 +8,15 @@ use teloxide::prelude::*;
 use teloxide::types::{ChatAction, InputFile, ParseMode, ThreadId};
 use tracing::{error, info, warn};
 
-use crate::agent_engine::{
-    archive_conversation, process_with_agent_with_events, AgentEvent, AgentRequestContext,
-};
-use crate::chat_commands::{build_model_response, build_status_response};
+use crate::agent_engine::{process_with_agent_with_events, AgentEvent, AgentRequestContext};
+use crate::chat_commands::handle_chat_command;
 use crate::runtime::AppState;
 use microclaw_channels::channel::ConversationKind;
 use microclaw_channels::channel_adapter::ChannelAdapter;
-use microclaw_core::llm_types::Message;
 #[cfg(test)]
 use microclaw_core::llm_types::{ContentBlock, ImageSource, MessageContent};
 use microclaw_core::text::floor_char_boundary;
 use microclaw_storage::db::{call_blocking, StoredMessage};
-use microclaw_storage::usage::build_usage_report;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct TelegramAccountConfig {
@@ -371,8 +367,7 @@ async fn handle_message(
     let mut image_data: Option<(String, String)> = None; // (base64, media_type)
     let mut document_saved_path: Option<String> = None;
 
-    // Handle /reset command — clear session
-    if text.trim() == "/reset" {
+    if text.trim_start().starts_with('/') {
         let external_chat_id = raw_chat_id.to_string();
         let chat_title_for_lookup = chat_title.clone();
         let chat_type_for_lookup = db_chat_type.to_string();
@@ -387,130 +382,10 @@ async fn handle_message(
         })
         .await
         .unwrap_or(raw_chat_id);
-        let _ = call_blocking(state.db.clone(), move |db| db.clear_chat_context(chat_id)).await;
-        let _ = bot
-            .send_message(msg.chat.id, "Context cleared (session + chat history).")
-            .await;
-        return Ok(());
-    }
-
-    // Handle /skills command — list available skills
-    if text.trim() == "/skills" {
-        let formatted = state.skills.list_skills_formatted();
-        let _ = bot.send_message(msg.chat.id, formatted).await;
-        return Ok(());
-    }
-
-    // Handle /reload-skills command — reload skills from disk
-    if text.trim() == "/reload-skills" {
-        let reloaded = state.skills.reload();
-        let count = reloaded.len();
-        let _ = bot
-            .send_message(msg.chat.id, format!("Reloaded {} skills from disk.", count))
-            .await;
-        return Ok(());
-    }
-
-    // Handle /archive command — archive current session to markdown
-    if text.trim() == "/archive" {
-        let external_chat_id = raw_chat_id.to_string();
-        let chat_title_for_lookup = chat_title.clone();
-        let chat_type_for_lookup = db_chat_type.to_string();
-        let channel_name = tg_channel_name.clone();
-        let chat_id = call_blocking(state.db.clone(), move |db| {
-            db.resolve_or_create_chat_id(
-                &channel_name,
-                &external_chat_id,
-                chat_title_for_lookup.as_deref(),
-                &chat_type_for_lookup,
-            )
-        })
-        .await
-        .unwrap_or(raw_chat_id);
-        if let Ok(Some((json, _))) =
-            call_blocking(state.db.clone(), move |db| db.load_session(chat_id)).await
-        {
-            let messages: Vec<Message> = serde_json::from_str(&json).unwrap_or_default();
-            if messages.is_empty() {
-                let _ = bot
-                    .send_message(msg.chat.id, "No session to archive.")
-                    .await;
-            } else {
-                archive_conversation(&state.config.data_dir, &tg_channel_name, chat_id, &messages);
-                let _ = bot
-                    .send_message(
-                        msg.chat.id,
-                        format!("Archived {} messages.", messages.len()),
-                    )
-                    .await;
-            }
-        } else {
-            let _ = bot
-                .send_message(msg.chat.id, "No session to archive.")
-                .await;
+        if let Some(reply) = handle_chat_command(&state, chat_id, &tg_channel_name, &text).await {
+            let _ = bot.send_message(msg.chat.id, reply).await;
+            return Ok(());
         }
-        return Ok(());
-    }
-
-    // Handle /usage command — token usage summary
-    if text.trim() == "/usage" {
-        let external_chat_id = raw_chat_id.to_string();
-        let chat_title_for_lookup = chat_title.clone();
-        let chat_type_for_lookup = db_chat_type.to_string();
-        let channel_name = tg_channel_name.clone();
-        let chat_id = call_blocking(state.db.clone(), move |db| {
-            db.resolve_or_create_chat_id(
-                &channel_name,
-                &external_chat_id,
-                chat_title_for_lookup.as_deref(),
-                &chat_type_for_lookup,
-            )
-        })
-        .await
-        .unwrap_or(raw_chat_id);
-        match build_usage_report(state.db.clone(), chat_id).await {
-            Ok(response) => {
-                let _ = bot.send_message(msg.chat.id, response).await;
-            }
-            Err(e) => {
-                let _ = bot
-                    .send_message(
-                        msg.chat.id,
-                        format!("Failed to query usage statistics: {e}"),
-                    )
-                    .await;
-            }
-        }
-        return Ok(());
-    }
-
-    // Handle /status command — runtime and session summary
-    if text.trim() == "/status" {
-        let external_chat_id = raw_chat_id.to_string();
-        let chat_title_for_lookup = chat_title.clone();
-        let chat_type_for_lookup = db_chat_type.to_string();
-        let channel_name = tg_channel_name.clone();
-        let chat_id = call_blocking(state.db.clone(), move |db| {
-            db.resolve_or_create_chat_id(
-                &channel_name,
-                &external_chat_id,
-                chat_title_for_lookup.as_deref(),
-                &chat_type_for_lookup,
-            )
-        })
-        .await
-        .unwrap_or(raw_chat_id);
-        let status =
-            build_status_response(state.db.clone(), &state.config, chat_id, &tg_channel_name).await;
-        let _ = bot.send_message(msg.chat.id, status).await;
-        return Ok(());
-    }
-
-    // Handle /model command — show current provider/model
-    if text.trim() == "/model" || text.trim_start().starts_with("/model ") {
-        let model_text = build_model_response(&state.config, &text);
-        let _ = bot.send_message(msg.chat.id, model_text).await;
-        return Ok(());
     }
 
     if let Some(photos) = msg.photo() {
@@ -1188,6 +1063,7 @@ mod tests {
         build_system_prompt, history_to_claude_messages, message_to_text, strip_images_for_session,
         strip_thinking,
     };
+    use microclaw_core::llm_types::Message;
     use microclaw_storage::db::StoredMessage;
 
     fn make_msg(id: &str, sender: &str, content: &str, is_bot: bool, ts: &str) -> StoredMessage {

--- a/src/chat_commands.rs
+++ b/src/chat_commands.rs
@@ -1,8 +1,68 @@
 use std::sync::Arc;
 
+use crate::agent_engine::archive_conversation;
 use crate::config::Config;
+use crate::runtime::AppState;
 use microclaw_core::llm_types::Message;
 use microclaw_storage::db::{call_blocking, Database};
+use microclaw_storage::usage::build_usage_report;
+
+pub async fn handle_chat_command(
+    state: &AppState,
+    chat_id: i64,
+    caller_channel: &str,
+    command_text: &str,
+) -> Option<String> {
+    let trimmed = command_text.trim();
+
+    if trimmed == "/reset" {
+        let _ = call_blocking(state.db.clone(), move |db| db.clear_chat_context(chat_id)).await;
+        return Some("Context cleared (session + chat history).".to_string());
+    }
+
+    if trimmed == "/skills" {
+        return Some(state.skills.list_skills_formatted());
+    }
+
+    if trimmed == "/reload-skills" {
+        let count = state.skills.reload().len();
+        return Some(format!("Reloaded {count} skills from disk."));
+    }
+
+    if trimmed == "/archive" {
+        if let Ok(Some((json, _))) =
+            call_blocking(state.db.clone(), move |db| db.load_session(chat_id)).await
+        {
+            let messages: Vec<Message> = serde_json::from_str(&json).unwrap_or_default();
+            if messages.is_empty() {
+                return Some("No session to archive.".to_string());
+            }
+            archive_conversation(&state.config.data_dir, caller_channel, chat_id, &messages);
+            return Some(format!("Archived {} messages.", messages.len()));
+        }
+        return Some("No session to archive.".to_string());
+    }
+
+    if trimmed == "/usage" {
+        let text = match build_usage_report(state.db.clone(), chat_id).await {
+            Ok(v) => v,
+            Err(e) => format!("Failed to query usage statistics: {e}"),
+        };
+        return Some(text);
+    }
+
+    if trimmed == "/status" {
+        return Some(
+            build_status_response(state.db.clone(), &state.config, chat_id, caller_channel).await,
+        );
+    }
+
+    if trimmed == "/model" || trimmed.starts_with("/model ") {
+        return Some(build_model_response(&state.config, trimmed));
+    }
+
+    None
+}
 
 pub async fn build_status_response(
     db: Arc<Database>,


### PR DESCRIPTION
## Summary
This PR centralizes chat slash command execution into a single runtime path and updates user-facing command documentation.

## Changes
- Added a single command entry point in `src/chat_commands.rs`:
  - `handle_chat_command(state, chat_id, caller_channel, command_text)`
- Moved command execution logic for these commands into that shared function:
  - `/reset`, `/skills`, `/reload-skills`, `/archive`, `/usage`, `/status`, `/model`
- Simplified channel adapters to a single command dispatch call:
  - `src/channels/telegram.rs`
  - `src/channels/discord.rs`
  - `src/channels/slack.rs`
  - `src/channels/feishu.rs`
  - `src/channels/irc.rs`
- Updated docs:
  - `README.md`
  - `README_CN.md`
  - `website/docs/commands.md`

## Why
Previously each channel duplicated nearly identical command branches. This made behavior drift likely and increased change cost for new command features.

This refactor makes behavior consistent across channels and gives a single place to extend command behavior safely.

## Validation
Ran full project check:
- `bash check.sh`

Passed, including:
- Rust tests
- web UI build
- website build
- docs drift check
