### PR TITLE
Fix #81: harden login limiter XFF handling and bucket growth

### DIFF
--- a/src/web/auth.rs
+++ b/src/web/auth.rs
@@ -84,7 +84,7 @@ pub(super) async fn api_auth_login(
     Json(body): Json<LoginRequest>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     metrics_http_inc(&state).await;
-    let client_key = client_key_from_headers(&headers);
+    let client_key = client_key_from_headers_with_config(&headers, &state.app_state.config);
     let allowed = state
         .auth_hub
         .allow_login_attempt(&client_key, 5, Duration::from_secs(60))


### PR DESCRIPTION
## Summary
- closes #81
- make login rate-limit client key default to `global` unless `channels.web.trust_x_forwarded_for: true`
- keep trusted-XFF parsing explicit/opt-in
- add bounded cleanup for auth buckets (`MAX_BUCKET_KEYS=4096`) to prevent key-spray memory growth
- add tests for default XFF behavior, trusted-XFF behavior, and bucket-cap behavior

## Validation
- cargo fmt --all
- cargo clippy --all-targets -- -D warnings
- cargo test
