### PR TITLE
[codex] dedupe inbound channel events and suppress duplicate final sends

### DIFF
--- a/src/channels/irc.rs
+++ b/src/channels/irc.rs
@@ -532,7 +532,14 @@ async fn handle_irc_message(
                 }
             }
 
-            if !response.is_empty() {
+            if used_send_message_tool {
+                if !response.is_empty() {
+                    info!(
+                        "IRC: suppressing final response for chat {} because send_message already delivered output",
+                        chat_id
+                    );
+                }
+            } else if !response.is_empty() {
                 if let Err(e) = adapter.send_text(&response_target, &response).await {
                     error!("IRC: failed to send response: {e}");
                 }
@@ -546,7 +553,7 @@ async fn handle_irc_message(
                 };
                 let _ =
                     call_blocking(app_state.db.clone(), move |db| db.store_message(&bot_msg)).await;
-            } else if !used_send_message_tool {
+            } else {
                 let fallback =
                     "I couldn't produce a visible reply after an automatic retry. Please try again.";
                 let _ = adapter.send_text(&response_target, fallback).await;

--- a/src/channels/qq.rs
+++ b/src/channels/qq.rs
@@ -337,6 +337,21 @@ async fn qq_webhook_handler(
     if chat_id == 0 {
         return axum::http::StatusCode::INTERNAL_SERVER_ERROR;
     }
+    if !payload.message_id.trim().is_empty() {
+        let already_seen = call_blocking(app_state.db.clone(), {
+            let message_id = payload.message_id.clone();
+            move |db| db.message_exists(chat_id, &message_id)
+        })
+        .await
+        .unwrap_or(false);
+        if already_seen {
+            info!(
+                "QQ: skipping duplicate message chat_id={} message_id={}",
+                chat_id, payload.message_id
+            );
+            return axum::http::StatusCode::OK;
+        }
+    }
     let stored = StoredMessage {
         id: if payload.message_id.trim().is_empty() {
             uuid::Uuid::new_v4().to_string()
@@ -390,7 +405,14 @@ async fn qq_webhook_handler(
                 runtime_ctx.channel_name.clone(),
                 runtime_ctx.send_command.clone(),
             );
-            if !response.is_empty() {
+            if used_send_message_tool {
+                if !response.is_empty() {
+                    info!(
+                        "QQ: suppressing final response for chat {} because send_message already delivered output",
+                        chat_id
+                    );
+                }
+            } else if !response.is_empty() {
                 if let Err(e) = adapter.send_text(user_id, &response).await {
                     error!("QQ: failed to send response: {e}");
                 }
@@ -404,7 +426,7 @@ async fn qq_webhook_handler(
                 };
                 let _ =
                     call_blocking(app_state.db.clone(), move |db| db.store_message(&bot_msg)).await;
-            } else if !used_send_message_tool {
+            } else {
                 let _ = adapter
                     .send_text(
                         user_id,

--- a/src/channels/signal.rs
+++ b/src/channels/signal.rs
@@ -345,6 +345,21 @@ async fn signal_webhook_handler(
     if chat_id == 0 {
         return axum::http::StatusCode::INTERNAL_SERVER_ERROR;
     }
+    if !payload.message_id.trim().is_empty() {
+        let already_seen = call_blocking(app_state.db.clone(), {
+            let message_id = payload.message_id.clone();
+            move |db| db.message_exists(chat_id, &message_id)
+        })
+        .await
+        .unwrap_or(false);
+        if already_seen {
+            info!(
+                "Signal: skipping duplicate message chat_id={} message_id={}",
+                chat_id, payload.message_id
+            );
+            return axum::http::StatusCode::OK;
+        }
+    }
     let stored = StoredMessage {
         id: if payload.message_id.trim().is_empty() {
             uuid::Uuid::new_v4().to_string()
@@ -398,7 +413,14 @@ async fn signal_webhook_handler(
                 runtime_ctx.channel_name.clone(),
                 runtime_ctx.send_command.clone(),
             );
-            if !response.is_empty() {
+            if used_send_message_tool {
+                if !response.is_empty() {
+                    info!(
+                        "Signal: suppressing final response for chat {} because send_message already delivered output",
+                        chat_id
+                    );
+                }
+            } else if !response.is_empty() {
                 if let Err(e) = adapter.send_text(sender, &response).await {
                     error!("Signal: failed to send response: {e}");
                 }
@@ -412,7 +434,7 @@ async fn signal_webhook_handler(
                 };
                 let _ =
                     call_blocking(app_state.db.clone(), move |db| db.store_message(&bot_msg)).await;
-            } else if !used_send_message_tool {
+            } else {
                 let _ = adapter
                     .send_text(
                         sender,

--- a/src/channels/slack.rs
+++ b/src/channels/slack.rs
@@ -642,12 +642,33 @@ async fn handle_slack_message(
         return;
     }
 
+    let inbound_message_id = if ts.is_empty() {
+        None
+    } else {
+        Some(ts.to_string())
+    };
+    if let Some(inbound_message_id) = inbound_message_id.as_deref() {
+        let already_seen = call_blocking(app_state.db.clone(), {
+            let inbound_message_id = inbound_message_id.to_string();
+            move |db| db.message_exists(chat_id, &inbound_message_id)
+        })
+        .await
+        .unwrap_or(false);
+        if already_seen {
+            info!(
+                "Slack: skipping duplicate message chat_id={} message_id={}",
+                chat_id, inbound_message_id
+            );
+            return;
+        }
+    }
+
     // Store incoming message
     let stored = StoredMessage {
-        id: if ts.is_empty() {
-            uuid::Uuid::new_v4().to_string()
+        id: if let Some(inbound_message_id) = inbound_message_id {
+            inbound_message_id
         } else {
-            ts.to_string()
+            uuid::Uuid::new_v4().to_string()
         },
         chat_id,
         sender_name: user.to_string(),
@@ -715,7 +736,14 @@ async fn handle_slack_message(
                 }
             }
 
-            if !response.is_empty() {
+            if used_send_message_tool {
+                if !response.is_empty() {
+                    info!(
+                        "Slack: suppressing final response for chat {} because send_message already delivered output",
+                        chat_id
+                    );
+                }
+            } else if !response.is_empty() {
                 if let Err(e) = send_slack_response(bot_token, channel, &response).await {
                     error!("Slack: failed to send response: {e}");
                 }
@@ -730,7 +758,7 @@ async fn handle_slack_message(
                 };
                 let _ =
                     call_blocking(app_state.db.clone(), move |db| db.store_message(&bot_msg)).await;
-            } else if !used_send_message_tool {
+            } else {
                 let fallback = "I couldn't produce a visible reply after an automatic retry. Please try again.";
                 let _ = send_slack_response(bot_token, channel, fallback).await;
 

--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -62,7 +62,10 @@ fn build_inbound_fingerprint(
         parts.push(format!("t={}", text.chars().take(200).collect::<String>()));
     }
     if let Some(caption) = msg.caption().map(str::trim).filter(|v| !v.is_empty()) {
-        parts.push(format!("c={}", caption.chars().take(200).collect::<String>()));
+        parts.push(format!(
+            "c={}",
+            caption.chars().take(200).collect::<String>()
+        ));
     }
     if let Some(group_id) = msg.media_group_id() {
         parts.push(format!("mg={}", group_id.0));
@@ -901,8 +904,7 @@ async fn handle_message(
                     timestamp: chrono::Utc::now().to_rfc3339(),
                 };
                 let _ = call_blocking(state.db.clone(), move |db| db.store_message(&bot_msg)).await;
-            }
-            else {
+            } else {
                 let fallback = "I couldn't produce a visible reply after an automatic retry. Please try again.".to_string();
                 send_response(&bot, msg.chat.id, &fallback, msg.thread_id).await;
                 let bot_msg = StoredMessage {

--- a/src/channels/whatsapp.rs
+++ b/src/channels/whatsapp.rs
@@ -576,6 +576,22 @@ async fn handle_whatsapp_message(
         return;
     }
 
+    if !message_id.trim().is_empty() {
+        let already_seen = call_blocking(app_state.db.clone(), {
+            let message_id = message_id.to_string();
+            move |db| db.message_exists(chat_id, &message_id)
+        })
+        .await
+        .unwrap_or(false);
+        if already_seen {
+            info!(
+                "WhatsApp: skipping duplicate message chat_id={} message_id={}",
+                chat_id, message_id
+            );
+            return;
+        }
+    }
+
     let stored = StoredMessage {
         id: if message_id.trim().is_empty() {
             uuid::Uuid::new_v4().to_string()
@@ -640,7 +656,14 @@ async fn handle_whatsapp_message(
                 }
             }
 
-            if !response.is_empty() {
+            if used_send_message_tool {
+                if !response.is_empty() {
+                    info!(
+                        "WhatsApp: suppressing final response for chat {} because send_message already delivered output",
+                        chat_id
+                    );
+                }
+            } else if !response.is_empty() {
                 if let Err(e) = send_whatsapp_text(
                     &reqwest::Client::new(),
                     &runtime.access_token,
@@ -664,7 +687,7 @@ async fn handle_whatsapp_message(
                 };
                 let _ =
                     call_blocking(app_state.db.clone(), move |db| db.store_message(&bot_msg)).await;
-            } else if !used_send_message_tool {
+            } else {
                 let fallback =
                     "I couldn't produce a visible reply after an automatic retry. Please try again.";
                 let _ = send_whatsapp_text(


### PR DESCRIPTION
## Summary
This PR fixes duplicate outbound replies and duplicate inbound processing across channel adapters.

Users observed intermittent double replies, especially when the model used `send_message` and still returned non-empty final text, and when webhook/polling retries delivered the same inbound event again.

## User Impact
Before this change:
- A single user message could trigger two bot outputs in the same channel.
- Provider retries/re-deliveries could cause the same inbound message to be processed multiple times, re-running tools and generating repeated side effects.

After this change:
- If a turn already delivered via `send_message`, the channel adapter suppresses the final direct response send.
- Channel adapters with stable inbound event IDs now perform idempotency checks and skip already-seen events.

## Root Cause
There were two independent causes:
1. Channel response logic prioritized non-empty final `response` over `used_send_message_tool`, so a turn that already sent via tool could still send again.
2. Most adapters stored inbound messages but did not short-circuit on duplicates before processing, so retry delivery could re-enter the full agent loop.

## Fix
### 1) Suppress final response when `send_message` already delivered
Applied across adapters:
- `src/channels/discord.rs`
- `src/channels/slack.rs`
- `src/channels/feishu.rs`
- `src/channels/signal.rs`
- `src/channels/qq.rs`
- `src/channels/dingtalk.rs`
- `src/channels/whatsapp.rs`
- `src/channels/email.rs`
- `src/channels/nostr.rs`
- `src/channels/matrix.rs`
- `src/channels/irc.rs`
- `src/channels/telegram.rs` (alignment/formatting and consistency with existing suppression behavior)

The adapter flow is now:
- if `used_send_message_tool`: suppress direct final send (log-only)
- else if final `response` non-empty: send
- else: send fallback

### 2) Add inbound idempotency checks with `message_exists`
Added duplicate short-circuit checks (when inbound IDs are available) before storing/processing in:
- `src/channels/telegram.rs`
- `src/channels/discord.rs`
- `src/channels/slack.rs` (when Slack `ts` is present)
- `src/channels/feishu.rs`
- `src/channels/signal.rs`
- `src/channels/qq.rs`
- `src/channels/dingtalk.rs`
- `src/channels/whatsapp.rs`
- `src/channels/email.rs`
- `src/channels/nostr.rs`
- `src/channels/matrix.rs` (messages + reactions)

This uses existing DB support (`message_exists`) and logs duplicate drops for observability.

## Validation
Ran the same lint/test gates used by CI:
- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`

All commands passed locally.
