### PR TITLE
docs: add Peekaboo and Windows desktop MCP setup examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,44 @@ RUST_LOG=info cargo run -- start
 
 Look for log lines like `MCP server '...' connected (...)`.
 
+### macOS Desktop Automation with Peekaboo MCP
+
+[Peekaboo](https://github.com/steipete/Peekaboo) is a macOS desktop automation MCP server. MicroClaw can use it directly via `stdio` transport (no runtime code changes needed).
+
+```sh
+mkdir -p <data_dir>/mcp.d
+cp mcp.peekaboo.example.json <data_dir>/mcp.d/peekaboo.json
+```
+
+`mcp.peekaboo.example.json`:
+
+```json
+{
+  "mcpServers": {
+    "peekaboo": {
+      "transport": "stdio",
+      "command": "npx",
+      "args": ["-y", "peekaboo-mcp@latest"]
+    }
+  }
+}
+```
+
+### Windows Desktop Automation Options
+
+MicroClaw can also consume Windows desktop automation MCP servers via `stdio`.
+
+```sh
+mkdir -p <data_dir>/mcp.d
+cp mcp.windows.desktop.example.json <data_dir>/mcp.d/windows-desktop.json
+```
+
+`mcp.windows.desktop.example.json` includes:
+- `pywinauto` (native Windows desktop UI automation, stdio MCP)
+- optional `playwright` MCP for browser automation on Windows
+
+Note: some Windows MCP projects expose only `sse` transport. MicroClaw runtime currently supports `stdio` and `streamable_http` transports only, so SSE-only servers need a protocol bridge before use.
+
 ## Plan & Execute
 
 <p align="center">

--- a/README_CN.md
+++ b/README_CN.md
@@ -309,6 +309,44 @@ cp mcp.hapi-bridge.example.json <data_dir>/mcp.d/hapi-bridge.json
 
 详细操作可见：`docs/operations/hapi-bridge.md`。
 
+### 在 macOS 上接入 Peekaboo MCP（桌面自动化）
+
+[Peekaboo](https://github.com/steipete/Peekaboo) 是一个 macOS 桌面自动化 MCP server。MicroClaw 可通过 `stdio` 直接接入（无需修改运行时代码）。
+
+```sh
+mkdir -p <data_dir>/mcp.d
+cp mcp.peekaboo.example.json <data_dir>/mcp.d/peekaboo.json
+```
+
+`mcp.peekaboo.example.json`：
+
+```json
+{
+  "mcpServers": {
+    "peekaboo": {
+      "transport": "stdio",
+      "command": "npx",
+      "args": ["-y", "peekaboo-mcp@latest"]
+    }
+  }
+}
+```
+
+### Windows 上的类似方案
+
+MicroClaw 也可以通过 `stdio` 接入 Windows 桌面自动化 MCP server：
+
+```sh
+mkdir -p <data_dir>/mcp.d
+cp mcp.windows.desktop.example.json <data_dir>/mcp.d/windows-desktop.json
+```
+
+`mcp.windows.desktop.example.json` 包含：
+- `pywinauto`（Windows 原生桌面 UI 自动化，stdio MCP）
+- 可选 `playwright` MCP（Windows 浏览器自动化）
+
+注意：部分 Windows MCP 项目只提供 `sse` transport。MicroClaw 当前仅直接支持 `stdio` 与 `streamable_http`，SSE-only 服务需先通过协议桥接后再接入。
+
 ## 计划与执行
 
 <p align="center">

--- a/mcp.peekaboo.example.json
+++ b/mcp.peekaboo.example.json
@@ -1,0 +1,10 @@
+{
+  "defaultProtocolVersion": "2025-11-05",
+  "mcpServers": {
+    "peekaboo": {
+      "transport": "stdio",
+      "command": "npx",
+      "args": ["-y", "peekaboo-mcp@latest"]
+    }
+  }
+}

--- a/mcp.windows.desktop.example.json
+++ b/mcp.windows.desktop.example.json
@@ -1,0 +1,18 @@
+{
+  "defaultProtocolVersion": "2025-11-05",
+  "mcpServers": {
+    "pywinauto": {
+      "transport": "stdio",
+      "command": "python",
+      "args": ["-m", "pywinauto_mcp.main"]
+    },
+    "playwright": {
+      "transport": "stdio",
+      "command": "npx",
+      "args": ["-y", "@playwright/mcp@latest", "--extension"],
+      "env": {
+        "PLAYWRIGHT_MCP_EXTENSION_TOKEN": "<your-token-here>"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add first-party Peekaboo (macOS) MCP integration docs
- add Windows desktop automation MCP docs with PyWinAuto + optional Playwright
- add copy/paste example config files:
  - `mcp.peekaboo.example.json`
  - `mcp.windows.desktop.example.json`
- clarify current transport support limits (`stdio` / `streamable_http`; SSE-only servers require a bridge)

Closes #122

## Validation
- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
