### PR TITLE
Add topic_mode option to the Feishu channel so replies are sent as threaded responses to the original message instead of new top-level messages.

### DIFF
--- a/src/channels/feishu.rs
+++ b/src/channels/feishu.rs
@@ -208,7 +208,7 @@ pub fn build_feishu_runtime_contexts(config: &crate::config::Config) -> Vec<Feis
             verification_token: account_cfg.verification_token.clone(),
             encrypt_key: account_cfg.encrypt_key.clone(),
             model: account_cfg.model.clone(),
-            topic_mode: account_cfg.topic_mode.clone(),
+            topic_mode: account_cfg.topic_mode,
             accounts: HashMap::new(),
             default_account: None,
         };


### PR DESCRIPTION
- FeishuAccountConfig 和 `FeishuChannelConfig` 新增 `topic_mode: bool`，`#[serde(default)]` 默认 `false`
- `build_feishu_runtime_contexts` 中从 `account config` 传播到 `channel config`
- `send_feishu_response` 新增 `message_id` 和 `topic_mode` 参数：
  - `topic_mode: false` → 原来的 `send message` API（/messages?receive_id_type=chat_id），直接发到群
  - `topic_mode: true` → `reply` API（/messages/{message_id}/reply + reply_in_thread: true），话题回复



YAML 配置示例：
```
channels:
  feishu:
    accounts:
      main:
        app_id: "cli_xxx"
        app_secret: "xxx"
        topic_mode: true  # 启用话题回复模式
 ```


<img width="2641" height="531" alt="image" src="https://github.com/user-attachments/assets/a4af91b5-b030-4f65-bad3-a3683d747dbc" />
