### PR TITLE
Expose the skills data directory as a read-only bind mount inside the Docker sandbox so containerized tools can access installed skill assets.

### DIFF
--- a/src/plugins.rs
+++ b/src/plugins.rs
@@ -899,6 +899,7 @@ async fn execute_with_template(
     let router = Arc::new(SandboxRouter::new(
         config.sandbox.clone(),
         &base_working_dir,
+        vec![],
     ));
     execute_command_with_policy(
         router,
@@ -1040,6 +1041,7 @@ async fn execute_plugin_tool_spec(
     let router = Arc::new(SandboxRouter::new(
         config.sandbox.clone(),
         &base_working_dir,
+        vec![],
     ));
     let result = execute_command_with_policy(
         router,


### PR DESCRIPTION
**问题：Docker 沙箱只挂载了 working_dir，skills 目录 (<data_dir>/skills) 未挂载进容器，导致沙箱内的 bash 工具无法访问 skill 相关的文件。**


**方案：在 DockerSandbox 上引入 extra_mounts 机制，而非直接挂载整个 data_dir（避免数据库、MCP 配置等敏感文件暴露）。**

## 改动文件

1. crates/microclaw-tools/src/sandbox.rs
   - 新增 ExtraMount 结构体（host_path + read_only）
   - DockerSandbox 增加 extra_mounts 字段
   - ensure_ready 中为每个 extra mount 生成 -v host:host:ro/rw 参数
   - SandboxRouter::new 增加 extra_mounts 参数并透传给 DockerSandbox
2. src/tools/mod.rs
   - 新增 ToolRegistry::build_extra_mounts() 方法：当 skills 目录存在且不等于 working_dir 时，自动将其作为只读挂载加入
   - new() 和 new_sub_agent() 都使用此机制
3. src/plugins.rs
   - 两处 SandboxRouter::new 调用补传 vec![]（plugins 暂不需要额外挂载）
   
## 设计要点

- 只读挂载：skills 内容仅供 agent 读取指令，sync_skills 工具本身是 Rust 直接写文件，不经过沙箱
- Identity mount：容器内路径和宿主一致（/path:/path:ro），skill 指令中的绝对路径无需翻译
- 安全：不暴露 data_dir 下的 SQLite DB、mcp.json 等敏感数据；仅挂载 skills 子目录
- 可扩展：Vec<ExtraMount> 设计可复用于未来 plugins 目录等场景