### PR TITLE
Add `get_time` built-in tool that returns current time

### DIFF
--- a/crates/microclaw-storage/src/db.rs
+++ b/crates/microclaw-storage/src/db.rs
@@ -1769,7 +1769,10 @@ impl Database {
         let conn = self.lock_conn();
         let tx = conn.unchecked_transaction()?;
         let mut affected = 0usize;
-        affected += tx.execute("DELETE FROM task_run_logs WHERE chat_id = ?1", params![chat_id])?;
+        affected += tx.execute(
+            "DELETE FROM task_run_logs WHERE chat_id = ?1",
+            params![chat_id],
+        )?;
         affected += tx.execute(
             "DELETE FROM scheduled_task_dlq WHERE chat_id = ?1",
             params![chat_id],
@@ -4300,11 +4303,10 @@ mod tests {
         assert!(db.get_recent_messages(100, 10).unwrap().is_empty());
         assert!(db.get_tasks_for_chat(100).unwrap().is_empty());
         assert!(db.get_task_run_logs(task_id, 10).unwrap().is_empty());
-        assert!(
-            db.list_scheduled_task_dlq(Some(100), Some(task_id), true, 10)
-                .unwrap()
-                .is_empty()
-        );
+        assert!(db
+            .list_scheduled_task_dlq(Some(100), Some(task_id), true, 10)
+            .unwrap()
+            .is_empty());
         assert!(!db.search_memories(100, "Rust", 10).unwrap().is_empty());
         assert!(db.get_chat_type(100).unwrap().is_some());
 

--- a/src/tools/get_time.rs
+++ b/src/tools/get_time.rs
@@ -1,0 +1,103 @@
+use async_trait::async_trait;
+use chrono::Utc;
+use serde_json::json;
+
+use super::{schema_object, Tool, ToolResult};
+use microclaw_core::llm_types::ToolDefinition;
+
+pub struct GetTimeTool {
+    default_timezone: String,
+}
+
+impl GetTimeTool {
+    pub fn new(default_timezone: String) -> Self {
+        GetTimeTool { default_timezone }
+    }
+}
+
+#[async_trait]
+impl Tool for GetTimeTool {
+    fn name(&self) -> &str {
+        "get_time"
+    }
+
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition {
+            name: "get_time".into(),
+            description: "Get the current time in a specified timezone. Returns the local time, UTC time, and Unix timestamp. Use this instead of running shell commands like `date` to get accurate time information.".into(),
+            input_schema: schema_object(
+                json!({
+                    "timezone": {
+                        "type": "string",
+                        "description": "IANA timezone name (e.g. 'Asia/Shanghai', 'US/Eastern', 'Europe/London'). Defaults to the server configured timezone if omitted."
+                    }
+                }),
+                &[],
+            ),
+        }
+    }
+
+    async fn execute(&self, input: serde_json::Value) -> ToolResult {
+        let tz_name = input
+            .get("timezone")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&self.default_timezone);
+
+        let tz: chrono_tz::Tz = match tz_name.parse() {
+            Ok(t) => t,
+            Err(_) => return ToolResult::error(format!("Invalid timezone: {tz_name}")),
+        };
+
+        let now_utc = Utc::now();
+        let now_local = now_utc.with_timezone(&tz);
+        let timestamp = now_utc.timestamp();
+
+        let result = format!(
+            "Timezone: {tz_name}\nLocal time: {}\nUTC time: {}\nUnix timestamp: {timestamp}",
+            now_local.format("%Y-%m-%d %H:%M:%S %Z"),
+            now_utc.format("%Y-%m-%d %H:%M:%S UTC"),
+        );
+
+        ToolResult::success(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn test_get_time_default_timezone() {
+        let tool = GetTimeTool::new("UTC".into());
+        let result = tool.execute(json!({})).await;
+        assert!(!result.is_error, "Error: {}", result.content);
+        assert!(result.content.contains("Timezone: UTC"));
+        assert!(result.content.contains("Unix timestamp:"));
+    }
+
+    #[tokio::test]
+    async fn test_get_time_with_timezone() {
+        let tool = GetTimeTool::new("UTC".into());
+        let result = tool.execute(json!({"timezone": "Asia/Shanghai"})).await;
+        assert!(!result.is_error, "Error: {}", result.content);
+        assert!(result.content.contains("Timezone: Asia/Shanghai"));
+        assert!(result.content.contains("Unix timestamp:"));
+    }
+
+    #[tokio::test]
+    async fn test_get_time_invalid_timezone() {
+        let tool = GetTimeTool::new("UTC".into());
+        let result = tool.execute(json!({"timezone": "Not/A/Zone"})).await;
+        assert!(result.is_error);
+        assert!(result.content.contains("Invalid timezone"));
+    }
+
+    #[tokio::test]
+    async fn test_get_time_uses_configured_default() {
+        let tool = GetTimeTool::new("Asia/Tokyo".into());
+        let result = tool.execute(json!({})).await;
+        assert!(!result.is_error, "Error: {}", result.content);
+        assert!(result.content.contains("Timezone: Asia/Tokyo"));
+    }
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -3,6 +3,7 @@ pub mod bash;
 pub mod browser;
 pub mod edit_file;
 pub mod export_chat;
+pub mod get_time;
 pub mod glob;
 pub mod grep;
 pub mod mcp;
@@ -115,6 +116,7 @@ impl ToolRegistry {
             Box::new(web_search::WebSearchTool::new(
                 config.tool_timeout_secs("web_search", 15),
             )),
+            Box::new(get_time::GetTimeTool::new(config.timezone.clone())),
             Box::new(send_message::SendMessageTool::new(
                 channel_registry.clone(),
                 db.clone(),
@@ -259,6 +261,7 @@ impl ToolRegistry {
             Box::new(web_search::WebSearchTool::new(
                 config.tool_timeout_secs("web_search", 15),
             )),
+            Box::new(get_time::GetTimeTool::new(config.timezone.clone())),
             Box::new(activate_skill::ActivateSkillTool::new(&skills_data_dir)),
             Box::new(structured_memory::StructuredMemorySearchTool::new(
                 db,


### PR DESCRIPTION
新增文件： src/tools/get_time.rs
- GetTimeTool，接收 config.timezone 作为默认时区
- 参数 timezone（可选），支持 IANA 时区名如 Asia/Shanghai
- 返回格式：
    Timezone: Asia/Shanghai
  Local time: 2026-02-28 09:07:49 CST
  UTC time: 2026-02-28 01:07:49 UTC
  Unix timestamp: 1740704869
  
修改文件： src/tools/mod.rs
- 添加 pub mod get_time;
- 在 ToolRegistry::new 和 ToolRegistry::new_sub_agent 中均注册了 GetTimeTool（sub-agent 也能用）
工具风险等级自动为 Low（只读，无副作用），不需要额外配置。Agent 注册定时任务时可以直接调用 get_time 获取准确时间，不再需要 bash 执行 date 命令了。