### PR TITLE
Refactor skill env injection from eagerly-loaded key-value maps to lazy env-file-path passing, with automatic output secret redaction and .env access blocking in bash tool

### DIFF
--- a/crates/microclaw-tools/src/env_file.rs
+++ b/crates/microclaw-tools/src/env_file.rs
@@ -1,0 +1,72 @@
+//! Dotenv file parsing utilities for skill environment injection.
+
+use std::collections::HashMap;
+
+/// Parse a dotenv-format string into a key-value map.
+///
+/// Supports:
+/// - `KEY=value`
+/// - `export KEY=value`
+/// - Quoted values (`"value"` or `'value'`)
+/// - Comments (`# ...`) and blank lines
+pub fn parse_dotenv(content: &str) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        if let Some(eq_pos) = trimmed.find('=') {
+            let key = trimmed[..eq_pos].trim();
+            if key.is_empty() {
+                continue;
+            }
+            let actual_key = key.strip_prefix("export ").map(str::trim).unwrap_or(key);
+            if actual_key.is_empty() {
+                continue;
+            }
+            let val = unquote_env_value(trimmed[eq_pos + 1..].trim());
+            map.insert(actual_key.to_string(), val);
+        }
+    }
+    map
+}
+
+fn unquote_env_value(s: &str) -> String {
+    if s.len() >= 2
+        && ((s.starts_with('"') && s.ends_with('"')) || (s.starts_with('\'') && s.ends_with('\'')))
+    {
+        return s[1..s.len() - 1].to_string();
+    }
+    s.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_dotenv_basic() {
+        let content = "KEY1=value1\nKEY2=value2\n# comment\n\nKEY3=\"quoted value\"";
+        let map = parse_dotenv(content);
+        assert_eq!(map.get("KEY1").unwrap(), "value1");
+        assert_eq!(map.get("KEY2").unwrap(), "value2");
+        assert_eq!(map.get("KEY3").unwrap(), "quoted value");
+        assert_eq!(map.len(), 3);
+    }
+
+    #[test]
+    fn test_parse_dotenv_export_prefix() {
+        let content = "export API_KEY=secret123\nexport BASE_URL='https://example.com'";
+        let map = parse_dotenv(content);
+        assert_eq!(map.get("API_KEY").unwrap(), "secret123");
+        assert_eq!(map.get("BASE_URL").unwrap(), "https://example.com");
+    }
+
+    #[test]
+    fn test_parse_dotenv_empty_and_comments() {
+        let content = "# full comment\n\n  \n";
+        let map = parse_dotenv(content);
+        assert!(map.is_empty());
+    }
+}

--- a/crates/microclaw-tools/src/lib.rs
+++ b/crates/microclaw-tools/src/lib.rs
@@ -1,6 +1,7 @@
 //! Tool runtime and built-in tool implementations for MicroClaw.
 
 pub mod command_runner;
+pub mod env_file;
 pub mod path_guard;
 pub mod runtime;
 pub mod sandbox;

--- a/src/plugins.rs
+++ b/src/plugins.rs
@@ -926,6 +926,7 @@ async fn execute_command_with_policy(
         timeout: std::time::Duration::from_secs(timeout_secs.max(1)),
         working_dir: Some(working_dir),
         envs: std::collections::HashMap::new(),
+        env_files: Vec::new(),
     };
 
     if !execution_policy.is_allowed(router.mode(), router.runtime_available()) {

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -2548,7 +2548,10 @@ impl SetupApp {
             return;
         }
         let step = window.max(1);
-        self.field_scroll = self.field_scroll.saturating_sub(step).min(visible.len() - 1);
+        self.field_scroll = self
+            .field_scroll
+            .saturating_sub(step)
+            .min(visible.len() - 1);
         self.selected = visible[self.field_scroll];
         self.adjust_field_scroll(window.max(1));
     }
@@ -2587,7 +2590,11 @@ impl SetupApp {
         while pos < visible.len() {
             let section = Self::section_for_key(&self.fields[visible[pos]].key);
             let added = if section != last_section {
-                if used_lines == 0 { 2 } else { 3 }
+                if used_lines == 0 {
+                    2
+                } else {
+                    3
+                }
             } else {
                 1
             };
@@ -4628,9 +4635,7 @@ fn draw_ui(frame: &mut ratatui::Frame<'_>, app: &SetupApp) {
         };
         let label_text = format!("{} {}: ", prefix, label);
         let line_width = left_inner.width.max(1) as usize;
-        let max_value_chars = line_width
-            .saturating_sub(label_text.chars().count())
-            .max(1);
+        let max_value_chars = line_width.saturating_sub(label_text.chars().count()).max(1);
         let value_single_line = truncate_single_line(&value, max_value_chars);
         lines.push(Line::from(vec![
             Span::styled(label_text, Style::default().fg(color)),

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -1,6 +1,5 @@
 use serde::Deserialize;
-use std::collections::HashMap;
-use std::path::{Component, Path, PathBuf};
+use std::path::PathBuf;
 
 #[derive(Debug, Clone)]
 pub struct SkillMetadata {
@@ -327,67 +326,6 @@ impl SkillManager {
     pub fn skills_dir(&self) -> &PathBuf {
         &self.skills_dir
     }
-}
-
-pub fn load_skill_env_vars(meta: &SkillMetadata) -> HashMap<String, String> {
-    let env_file_name = match &meta.env_file {
-        Some(f) => f.as_str(),
-        None => return HashMap::new(),
-    };
-    if !is_safe_env_file_path(env_file_name) {
-        return HashMap::new();
-    }
-    let env_path = meta.dir_path.join(env_file_name);
-    let content = match std::fs::read_to_string(&env_path) {
-        Ok(c) => c,
-        Err(_) => return HashMap::new(),
-    };
-    parse_dotenv(&content)
-}
-
-fn is_safe_env_file_path(env_file_name: &str) -> bool {
-    let path = Path::new(env_file_name);
-    if path.is_absolute() {
-        return false;
-    }
-    !path.components().any(|component| {
-        matches!(
-            component,
-            Component::ParentDir | Component::RootDir | Component::Prefix(_)
-        )
-    })
-}
-
-fn parse_dotenv(content: &str) -> HashMap<String, String> {
-    let mut map = HashMap::new();
-    for line in content.lines() {
-        let trimmed = line.trim();
-        if trimmed.is_empty() || trimmed.starts_with('#') {
-            continue;
-        }
-        if let Some(eq_pos) = trimmed.find('=') {
-            let key = trimmed[..eq_pos].trim();
-            if key.is_empty() {
-                continue;
-            }
-            let actual_key = key.strip_prefix("export ").map(str::trim).unwrap_or(key);
-            if actual_key.is_empty() {
-                continue;
-            }
-            let val = unquote_env_value(trimmed[eq_pos + 1..].trim());
-            map.insert(actual_key.to_string(), val);
-        }
-    }
-    map
-}
-
-fn unquote_env_value(s: &str) -> String {
-    if s.len() >= 2
-        && ((s.starts_with('"') && s.ends_with('"')) || (s.starts_with('\'') && s.ends_with('\'')))
-    {
-        return s[1..s.len() - 1].to_string();
-    }
-    s.to_string()
 }
 
 fn current_platform() -> &'static str {
@@ -863,100 +801,6 @@ nope
         let err = sm.load_skill_checked("bad").unwrap_err();
         assert!(err.contains("currently unavailable"));
         assert!(err.contains("available --all"));
-        let _ = std::fs::remove_dir_all(&dir);
-    }
-
-    #[test]
-    fn test_parse_dotenv_basic() {
-        let content = "KEY1=value1\nKEY2=value2\n# comment\n\nKEY3=\"quoted value\"";
-        let map = parse_dotenv(content);
-        assert_eq!(map.get("KEY1").unwrap(), "value1");
-        assert_eq!(map.get("KEY2").unwrap(), "value2");
-        assert_eq!(map.get("KEY3").unwrap(), "quoted value");
-        assert_eq!(map.len(), 3);
-    }
-
-    #[test]
-    fn test_parse_dotenv_export_prefix() {
-        let content = "export API_KEY=secret123\nexport BASE_URL='https://example.com'";
-        let map = parse_dotenv(content);
-        assert_eq!(map.get("API_KEY").unwrap(), "secret123");
-        assert_eq!(map.get("BASE_URL").unwrap(), "https://example.com");
-    }
-
-    #[test]
-    fn test_parse_dotenv_empty_and_comments() {
-        let content = "# full comment\n\n  \n";
-        let map = parse_dotenv(content);
-        assert!(map.is_empty());
-    }
-
-    #[test]
-    fn test_load_skill_env_vars_with_env_file() {
-        let dir =
-            std::env::temp_dir().join(format!("microclaw_skill_env_test_{}", uuid::Uuid::new_v4()));
-        std::fs::create_dir_all(&dir).unwrap();
-        std::fs::write(
-            dir.join(".env"),
-            "OUTLINE_API_KEY=test123\nOUTLINE_URL=https://outline.example.com\n",
-        )
-        .unwrap();
-        let meta = SkillMetadata {
-            name: "outline".to_string(),
-            description: "test".to_string(),
-            dir_path: dir.clone(),
-            platforms: vec![],
-            deps: vec![],
-            source: "local".to_string(),
-            version: None,
-            updated_at: None,
-            env_file: Some(".env".to_string()),
-        };
-        let envs = load_skill_env_vars(&meta);
-        assert_eq!(envs.get("OUTLINE_API_KEY").unwrap(), "test123");
-        assert_eq!(
-            envs.get("OUTLINE_URL").unwrap(),
-            "https://outline.example.com"
-        );
-        let _ = std::fs::remove_dir_all(&dir);
-    }
-
-    #[test]
-    fn test_load_skill_env_vars_no_env_file() {
-        let meta = SkillMetadata {
-            name: "test".to_string(),
-            description: "test".to_string(),
-            dir_path: PathBuf::from("/nonexistent"),
-            platforms: vec![],
-            deps: vec![],
-            source: "local".to_string(),
-            version: None,
-            updated_at: None,
-            env_file: None,
-        };
-        let envs = load_skill_env_vars(&meta);
-        assert!(envs.is_empty());
-    }
-
-    #[test]
-    fn test_load_skill_env_vars_rejects_parent_path() {
-        let dir =
-            std::env::temp_dir().join(format!("microclaw_skill_env_test_{}", uuid::Uuid::new_v4()));
-        std::fs::create_dir_all(&dir).unwrap();
-        std::fs::write(dir.join(".env"), "KEY=VALUE\n").unwrap();
-        let meta = SkillMetadata {
-            name: "test".to_string(),
-            description: "test".to_string(),
-            dir_path: dir.clone(),
-            platforms: vec![],
-            deps: vec![],
-            source: "local".to_string(),
-            version: None,
-            updated_at: None,
-            env_file: Some("../.env".to_string()),
-        };
-        let envs = load_skill_env_vars(&meta);
-        assert!(envs.is_empty());
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -583,6 +583,7 @@ mod tests {
             caller_channel: "web".into(),
             caller_chat_id: 1,
             control_chat_ids: vec![],
+            env_files: vec![],
         };
 
         let first = registry.execute_with_auth("bash", json!({}), &auth).await;
@@ -619,6 +620,7 @@ mod tests {
             caller_channel: "telegram".into(),
             caller_chat_id: 123,
             control_chat_ids: vec![123],
+            env_files: vec![],
         };
 
         let first = registry.execute_with_auth("bash", json!({}), &auth).await;
@@ -651,6 +653,7 @@ mod tests {
             caller_channel: "web".into(),
             caller_chat_id: 1,
             control_chat_ids: vec![],
+            env_files: vec![],
         };
 
         let result = registry
@@ -701,6 +704,7 @@ tools:
             caller_channel: "web".into(),
             caller_chat_id: 7,
             control_chat_ids: vec![],
+            env_files: vec![],
         };
 
         let defs = registry.definitions();
@@ -730,6 +734,7 @@ tools:
             caller_channel: "feishu".into(),
             caller_chat_id: 8009499081,
             control_chat_ids: vec![],
+            env_files: vec![],
         };
 
         let result = registry
@@ -759,6 +764,7 @@ tools:
             caller_channel: "feishu".into(),
             caller_chat_id: 8009499081,
             control_chat_ids: vec![],
+            env_files: vec![],
         };
 
         let result = registry

--- a/tests/tool_permissions.rs
+++ b/tests/tool_permissions.rs
@@ -15,6 +15,7 @@ fn test_auth_context_control_chat() {
         caller_channel: "telegram".into(),
         caller_chat_id: 100,
         control_chat_ids: vec![100, 200],
+        env_files: vec![],
     };
     assert!(auth.is_control_chat());
     assert!(auth.can_access_chat(999)); // control can access any chat
@@ -26,6 +27,7 @@ fn test_auth_context_regular_chat() {
         caller_channel: "telegram".into(),
         caller_chat_id: 300,
         control_chat_ids: vec![100, 200],
+        env_files: vec![],
     };
     assert!(!auth.is_control_chat());
     assert!(auth.can_access_chat(300)); // can access own chat
@@ -38,6 +40,7 @@ fn test_auth_context_empty_control_list() {
         caller_channel: "telegram".into(),
         caller_chat_id: 100,
         control_chat_ids: vec![],
+        env_files: vec![],
     };
     assert!(!auth.is_control_chat());
     assert!(auth.can_access_chat(100)); // can access own


### PR DESCRIPTION
1. 不再解析 .env 文件内容存储到 DB，改为传递 .env 文件路径。Docker sandbox 用 --env-file 参数，host 模式在执行时才解析。
2. 增加一些安全措施，禁止大模型读取.env文件


| 防线 | 实现 | 效果 |
|------|------|------|
| 路径隐蔽 | env file 路径从 __microclaw_env_files（AI 可见的 tool input）移到 __microclaw_auth.env_files（runtime 内部块） | AI 完全看不到 .env 文件路径，无法定向攻击 |
| 输出脱敏 | bash 工具输出经过 redact_env_secrets，长度 ≥8 的 env value 被替换为 [REDACTED:KEY] | env/printenv 输出中的 secret 值被屏蔽 |
| 命令拦截 | 当有活跃的 skill env files 时，bash 命令内容包含 .env/dotenv/env_file 则拒绝执行 | 阻止 cat .env 等直接访问（防君子层） |

<img width="1380" height="670" alt="image" src="https://github.com/user-attachments/assets/74dfaae2-1da9-47f7-b8ec-f6a27a7dca3c" />
