### PR TITLE
Add `Accept` and `mcp-protocol-version` headers to MCP HTTP requests for improved protocol compliance.

### DIFF
--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -716,7 +716,12 @@ impl McpServer {
             params,
         };
 
-        let mut req = inner.client.post(&inner.endpoint).json(&request);
+        let mut req = inner
+            .client
+            .post(&inner.endpoint)
+            .json(&request)
+            .header("accept", "application/json, text/event-stream")
+            .header("mcp-protocol-version", self.protocol_version());
         for (k, v) in &inner.headers {
             req = req.header(k, v);
         }
@@ -832,7 +837,12 @@ impl McpServer {
                     params,
                 };
 
-                let mut req = inner.client.post(&inner.endpoint).json(&request);
+                let mut req = inner
+                    .client
+                    .post(&inner.endpoint)
+                    .json(&request)
+                    .header("accept", "application/json, text/event-stream")
+                    .header("mcp-protocol-version", self.protocol_version());
                 for (k, v) in &inner.headers {
                     req = req.header(k, v);
                 }


### PR DESCRIPTION
### 问题根因

MicroClaw 的 HTTP 传输缺少 MCP Streamable HTTP 规范要求的请求头。MCP 服务器完全支持标准 MCP JSON-RPC 握手，但没有 `Accept: application/json, text/event-stream` 头时，服务器可能返回非 JSON 格式，导致 response.json() 解析失败：

```
Failed to connect MCP server 'browseros': Failed to parse HTTP MCP response: error decoding response body
```

### 修复内容（src/mcp.rs）
在 `send_request_http` 和 `send_notification`（StreamableHttp 分支）中添加两个请求头：
```
.header("accept", "application/json, text/event-stream")
.header("mcp-protocol-version", self.protocol_version())
```

正确对齐 MCP 规范

<img width="2761" height="1070" alt="image" src="https://github.com/user-attachments/assets/48ab5471-a024-42fb-9d37-7ff06cff5a51" />
