### PR TITLE
[codex] add /clear command to clear context without removing scheduled tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,8 @@ See full manifest schema and examples: `docs/plugins/overview.md`.
 
 **Commands:**
 - `/stop` -- abort the current active run in this chat (keeps history/session data)
-- `/reset` -- clear current chat context (session + chat history)
+- `/clear` -- clear current chat context (session + chat history), keep scheduled tasks
+- `/reset` -- clear current chat context (session + chat history) and scheduled task state
 - `/skills` -- list all available skills
 - `/reload-skills` -- reload skills from disk
 - `/archive` -- archive current in-memory session as markdown
@@ -346,7 +347,7 @@ Command handling rules:
 - Inputs with leading mentions before slash are also treated as commands (for example `@bot /status`, `<@U123> /status`).
 - Slash commands do **not** enter agent conversation history/session context.
 - Unknown slash commands return `Unknown command.`.
-- Use `/stop` to interrupt an in-flight run; use `/reset` to wipe chat context.
+- Use `/stop` to interrupt an in-flight run, `/clear` to wipe chat context only, and `/reset` to wipe chat context plus scheduled task state.
 
 ## MCP
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -280,7 +280,8 @@ MicroClaw 支持 [Anthropic Agent Skills](https://github.com/anthropics/skills) 
 
 **命令：**
 - `/stop` -- 中止当前聊天正在执行的 run（保留历史/会话数据）
-- `/reset` -- 清除当前聊天上下文（会话 + 聊天历史）
+- `/clear` -- 清除当前聊天上下文（会话 + 聊天历史），保留定时任务
+- `/reset` -- 清除当前聊天上下文（会话 + 聊天历史）并清空定时任务状态
 - `/skills` -- 列出所有可用技能
 - `/reload-skills` -- 从磁盘重新加载技能
 - `/archive` -- 将当前内存会话归档为 markdown
@@ -293,7 +294,7 @@ MicroClaw 支持 [Anthropic Agent Skills](https://github.com/anthropics/skills) 
 - 支持“前置提及 + slash”形式（例如 `@bot /status`、`<@U123> /status`）。
 - slash 命令不会写入 agent 会话上下文。
 - 未知 slash 命令返回 `Unknown command.`。
-- 需要中断正在执行的请求时用 `/stop`；需要清空上下文时用 `/reset`。
+- 需要中断正在执行的请求时用 `/stop`；仅清空上下文用 `/clear`；清空上下文并重置定时任务用 `/reset`。
 
 ## MCP
 

--- a/crates/microclaw-storage/src/db.rs
+++ b/crates/microclaw-storage/src/db.rs
@@ -1826,9 +1826,8 @@ impl Database {
         Ok(rows > 0)
     }
 
-    /// Clear conversational context for a chat without deleting chat metadata or memories.
-    /// This removes resumable session state, historical messages, and scheduled task state
-    /// that can otherwise continue producing messages after a reset.
+    /// Clear all resettable chat state without deleting chat metadata or memories.
+    /// This removes resumable session state, historical messages, and scheduled task state.
     pub fn clear_chat_context(&self, chat_id: i64) -> Result<bool, MicroClawError> {
         let conn = self.lock_conn();
         let tx = conn.unchecked_transaction()?;
@@ -1845,6 +1844,18 @@ impl Database {
             "DELETE FROM scheduled_tasks WHERE chat_id = ?1",
             params![chat_id],
         )?;
+        affected += tx.execute("DELETE FROM sessions WHERE chat_id = ?1", params![chat_id])?;
+        affected += tx.execute("DELETE FROM messages WHERE chat_id = ?1", params![chat_id])?;
+        tx.commit()?;
+        Ok(affected > 0)
+    }
+
+    /// Clear conversational context for a chat while preserving scheduled task state.
+    /// This removes resumable session state and historical messages only.
+    pub fn clear_chat_conversation(&self, chat_id: i64) -> Result<bool, MicroClawError> {
+        let conn = self.lock_conn();
+        let tx = conn.unchecked_transaction()?;
+        let mut affected = 0usize;
         affected += tx.execute("DELETE FROM sessions WHERE chat_id = ?1", params![chat_id])?;
         affected += tx.execute("DELETE FROM messages WHERE chat_id = ?1", params![chat_id])?;
         tx.commit()?;
@@ -4407,6 +4418,69 @@ mod tests {
             .list_scheduled_task_dlq(Some(100), Some(task_id), true, 10)
             .unwrap()
             .is_empty());
+        assert!(!db.search_memories(100, "Rust", 10).unwrap().is_empty());
+        assert!(db.get_chat_type(100).unwrap().is_some());
+
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn test_clear_chat_conversation_keeps_scheduled_tasks() {
+        let (db, dir) = test_db();
+        db.upsert_chat(100, Some("chat-100"), "private").unwrap();
+        db.save_session(100, r#"[{"role":"user","content":"hi"}]"#)
+            .unwrap();
+        db.store_message(&StoredMessage {
+            id: "m1".into(),
+            chat_id: 100,
+            sender_name: "alice".into(),
+            content: "hello".into(),
+            is_from_bot: false,
+            timestamp: "2024-01-01T00:00:01Z".into(),
+        })
+        .unwrap();
+        db.insert_memory(Some(100), "User likes Rust", "PROFILE")
+            .unwrap();
+        let task_id = db
+            .create_scheduled_task(
+                100,
+                "daily summary",
+                "cron",
+                "0 0 8 * * *",
+                "2099-01-01T08:00:00Z",
+            )
+            .unwrap();
+        db.log_task_run(
+            task_id,
+            100,
+            "2024-01-01T08:00:00Z",
+            "2024-01-01T08:00:01Z",
+            1000,
+            true,
+            Some("ok"),
+        )
+        .unwrap();
+        db.insert_scheduled_task_dlq(
+            task_id,
+            100,
+            "2024-01-01T09:00:00Z",
+            "2024-01-01T09:00:01Z",
+            1000,
+            Some("failure"),
+        )
+        .unwrap();
+
+        assert!(db.clear_chat_conversation(100).unwrap());
+        assert!(db.load_session(100).unwrap().is_none());
+        assert!(db.get_recent_messages(100, 10).unwrap().is_empty());
+        assert_eq!(db.get_tasks_for_chat(100).unwrap().len(), 1);
+        assert_eq!(db.get_task_run_logs(task_id, 10).unwrap().len(), 1);
+        assert_eq!(
+            db.list_scheduled_task_dlq(Some(100), Some(task_id), true, 10)
+                .unwrap()
+                .len(),
+            1
+        );
         assert!(!db.search_memories(100, "Rust", 10).unwrap().is_empty());
         assert!(db.get_chat_type(100).unwrap().is_some());
 

--- a/src/chat_commands.rs
+++ b/src/chat_commands.rs
@@ -54,6 +54,18 @@ pub async fn handle_chat_command(
 ) -> Option<String> {
     let trimmed = normalized_slash_command(command_text)?.trim();
 
+    if trimmed == "/clear" {
+        let _ = call_blocking(state.db.clone(), move |db| {
+            db.clear_chat_conversation(chat_id)
+        })
+        .await;
+        let groups_dir = std::path::PathBuf::from(&state.config.data_dir).join("groups");
+        if let Err(e) = clear_todos(&groups_dir, caller_channel, chat_id) {
+            warn!("Failed to clear TODO.json for chat {}: {}", chat_id, e);
+        }
+        return Some("Context cleared (session + chat history, scheduled tasks kept).".to_string());
+    }
+
     if trimmed == "/reset" {
         let _ = call_blocking(state.db.clone(), move |db| db.clear_chat_context(chat_id)).await;
         let groups_dir = std::path::PathBuf::from(&state.config.data_dir).join("groups");

--- a/src/web.rs
+++ b/src/web.rs
@@ -1511,6 +1511,18 @@ async fn handle_web_slash_command(state: &WebState, text: &str, chat_id: i64) ->
         return Some("Context cleared (session + chat history).".to_string());
     }
 
+    if trimmed == "/clear" {
+        let _ = call_blocking(state.app_state.db.clone(), move |db| {
+            db.clear_chat_conversation(chat_id)
+        })
+        .await;
+        let groups_dir = PathBuf::from(&state.app_state.config.data_dir).join("groups");
+        if let Err(e) = clear_todos(&groups_dir, "web", chat_id) {
+            warn!("Failed to clear TODO.json for chat {}: {}", chat_id, e);
+        }
+        return Some("Context cleared (session + chat history, scheduled tasks kept).".to_string());
+    }
+
     if trimmed == "/stop" {
         let stopped = crate::run_control::abort_runs("web", chat_id).await;
         if stopped > 0 {
@@ -2964,6 +2976,74 @@ mod tests {
             .and_then(|x| x.as_str())
             .unwrap_or_default();
         assert!(response.contains("Current provider/model"));
+    }
+
+    #[tokio::test]
+    async fn test_web_clear_slash_keeps_scheduled_tasks() {
+        let web_state = test_web_state(Box::new(DummyLlm), None, WebLimits::default());
+        let app = build_router(web_state.clone());
+        let db = web_state.app_state.db.clone();
+        call_blocking(db, move |d| {
+            d.upsert_chat(4242, Some("chat:4242"), "web")?;
+            d.save_session(4242, r#"[{"role":"user","content":"hi"}]"#)?;
+            d.store_message(&StoredMessage {
+                id: "m1".into(),
+                chat_id: 4242,
+                sender_name: "alice".into(),
+                content: "hello".into(),
+                is_from_bot: false,
+                timestamp: "2024-01-01T00:00:01Z".into(),
+            })?;
+            d.create_scheduled_task(
+                4242,
+                "daily summary",
+                "cron",
+                "0 0 8 * * *",
+                "2099-01-01T08:00:00Z",
+            )?;
+            Ok::<(), microclaw_core::error::MicroClawError>(())
+        })
+        .await
+        .unwrap();
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/send")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"session_key":"chat:4242","sender_name":"u","message":"/clear"}"#,
+            ))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            v.get("response").and_then(|x| x.as_str()),
+            Some("Context cleared (session + chat history, scheduled tasks kept).")
+        );
+
+        let db = web_state.app_state.db.clone();
+        let (session, messages, tasks_len) = call_blocking(db, move |d| {
+            Ok::<
+                (Option<(String, String)>, Vec<StoredMessage>, usize),
+                microclaw_core::error::MicroClawError,
+            >((
+                d.load_session(4242)?,
+                d.get_recent_messages(4242, 10)?,
+                d.get_tasks_for_chat(4242)?.len(),
+            ))
+        })
+        .await
+        .unwrap();
+        assert!(session.is_none());
+        assert!(
+            messages.iter().all(|m| m.content != "hello"),
+            "old chat history should be removed by /clear"
+        );
+        assert_eq!(tasks_len, 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
This PR adds a new `/clear` slash command that clears chat conversation context without deleting scheduled tasks.

Closes #172.

## User Impact
Before this change, users could only use `/reset`, which clears both conversation context and scheduled task state. This made it easy to unintentionally remove task state when the real intention was only to reset the conversation.

After this change:
- `/clear` clears session + chat history while keeping scheduled tasks (and their logs/DLQ state).
- `/reset` keeps its existing behavior and still clears scheduled task state in addition to conversation context.

## Root Cause
The existing reset path had a single “clear chat context” implementation that included scheduled task cleanup. There was no separate command/path for conversation-only cleanup.

## Fix
- Added a new DB API:
  - `clear_chat_conversation(chat_id)` deletes only `sessions` and `messages`.
- Added `/clear` handling in channel slash command handling:
  - `src/chat_commands.rs`
- Added `/clear` handling for Web slash commands:
  - `src/web.rs`
- Kept `/reset` behavior unchanged (still uses `clear_chat_context`).
- Updated docs in:
  - `README.md`
  - `README_CN.md`
- Added regression tests:
  - `crates/microclaw-storage/src/db.rs` test ensures `/clear`-equivalent DB path keeps scheduled tasks/logs/DLQ
  - `src/web.rs` test ensures `/clear` via web command clears conversation state but keeps scheduled tasks

## Validation
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -q -p microclaw-storage test_clear_chat_conversation_keeps_scheduled_tasks`
- `cargo test -q test_web_clear_slash_keeps_scheduled_tasks`
