### PR TITLE
[codex] harden sandbox defaults and add podman runtime support

### DIFF
--- a/crates/microclaw-tools/src/sandbox.rs
+++ b/crates/microclaw-tools/src/sandbox.rs
@@ -31,7 +31,7 @@ fn default_sandbox_no_network() -> bool {
 }
 
 fn default_sandbox_require_runtime() -> bool {
-    false
+    true
 }
 
 fn default_sandbox_mount_allowlist_path() -> Option<String> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1481,6 +1481,7 @@ voice_transcription_command: "whisper-mlx --file {file}"
         let config: Config = serde_yaml::from_str(yaml).unwrap();
         assert!(matches!(config.sandbox.mode, SandboxMode::Off));
         assert!(matches!(config.sandbox.backend, SandboxBackend::Auto));
+        assert!(config.sandbox.require_runtime);
         assert_eq!(config.sandbox.image, "ubuntu:25.10");
     }
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -5356,7 +5356,7 @@ pub fn enable_sandbox_in_config() -> Result<String, MicroClawError> {
     cfg.sandbox.mode = SandboxMode::All;
     cfg.sandbox.backend = SandboxBackend::Auto;
     cfg.sandbox.no_network = true;
-    cfg.sandbox.require_runtime = false;
+    cfg.sandbox.require_runtime = true;
     cfg.save_yaml(&path.to_string_lossy())?;
     Ok(path.to_string_lossy().to_string())
 }
@@ -5585,6 +5585,7 @@ sandbox:
         assert!(out.contains(path.to_string_lossy().as_ref()));
         let cfg = Config::load().unwrap();
         assert!(matches!(cfg.sandbox.mode, SandboxMode::All));
+        assert!(cfg.sandbox.require_runtime);
         std::env::remove_var("MICROCLAW_CONFIG");
         let _ = std::fs::remove_file(path);
     }


### PR DESCRIPTION
## Summary
This PR strengthens MicroClaw sandbox behavior and improves runtime portability.

It now includes two groups of changes:

1. **Fail-closed default** for sandbox runtime availability.
2. **Container runtime portability** by adding Podman support and backend-aware diagnostics.

Closes #185.

## What changed

### 1) Sandbox fail-closed defaults
- Changed `SandboxConfig` default `require_runtime` from `false` to `true`.
- Updated `microclaw setup --enable-sandbox` to persist `require_runtime: true`.
- Updated setup/config tests accordingly.

### 2) Podman support for sandbox runtime
- Extended `SandboxBackend` with `podman`.
- Added backend-aware runtime resolution helpers in `microclaw-tools::sandbox`:
  - runtime availability by backend
  - selected runtime CLI
- `SandboxRouter` now resolves runtime by backend:
  - `auto`: prefer `docker`, then `podman`
  - `docker`: require docker runtime
  - `podman`: require podman runtime

### 3) Runtime-aware diagnostics and self-check output
- `doctor sandbox` now validates container runtime CLIs/runtime status in a backend-aware way (Docker/Podman), instead of Docker-only checks.
- Web config self-check now uses backend-aware runtime detection and includes `sandbox_runtime_cli` in response payload.
- Runtime-unavailable messaging now uses “container runtime” language.

### 4) Docs and operator UX
- Updated security execution model doc to describe container backends (`auto` / `docker` / `podman`).
- Updated setup tip text to “container runtime”.
- Added comparison report:
  - `docs/reports/sandbox-comparison-openclaw-nanoclaw-zeroclaw-2026-03.md`

## Why
The OpenClaw/NanoClaw/ZeroClaw comparison highlighted two immediate improvements for MicroClaw:

1. Stronger strict-mode semantics when sandbox is enabled.
2. Better runtime portability across host environments where Podman is preferred.

This PR implements both while preserving explicit opt-out behavior (`require_runtime: false`) for local developer workflows.

## Validation
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -p microclaw-tools test_pick_runtime_matrix -- --test-threads=1`
- `cargo test doctor::tests::test_build_sandbox_report_has_mode_check -- --test-threads=1`
- `cargo test setup::tests::test_enable_sandbox_in_config_updates_mode -- --test-threads=1`

## Notes
- Full `cargo test` in this environment still has unrelated pre-existing permission failures (`Operation not permitted`) outside this diff.
