### PR TITLE
[codex] fix openai-compatible base routing for google/custom endpoints

### DIFF
--- a/src/chat_commands.rs
+++ b/src/chat_commands.rs
@@ -551,9 +551,24 @@ fn resolve_openai_models_url(profile: &ResolvedLlmProviderProfile) -> String {
     let backend = profile.provider.trim().to_ascii_lowercase();
     let default_base = match backend.as_str() {
         "openai" => "https://api.openai.com/v1",
+        "openrouter" => "https://openrouter.ai/api/v1",
+        "ollama" => "http://127.0.0.1:11434/v1",
+        "google" => "https://generativelanguage.googleapis.com/v1beta/openai",
+        "alibaba" => "https://dashscope.aliyuncs.com/compatible-mode/v1",
         "deepseek" => "https://api.deepseek.com/v1",
         "synthetic" => "https://api.synthetic.new/openai/v1",
         "chutes" => "https://llm.chutes.ai/v1",
+        "moonshot" => "https://api.moonshot.cn/v1",
+        "mistral" => "https://api.mistral.ai/v1",
+        "azure" => "https://YOUR-RESOURCE.openai.azure.com/openai/deployments/YOUR-DEPLOYMENT",
+        "bedrock" => "https://bedrock-runtime.YOUR-REGION.amazonaws.com/openai/v1",
+        "zhipu" => "https://open.bigmodel.cn/api/paas/v4",
+        "minimax" => "https://api.minimax.io/v1",
+        "cohere" => "https://api.cohere.ai/compatibility/v1",
+        "tencent" => "https://api.hunyuan.cloud.tencent.com/v1",
+        "xai" => "https://api.x.ai/v1",
+        "huggingface" => "https://router.huggingface.co/v1",
+        "together" => "https://api.together.xyz/v1",
         _ => "https://api.openai.com/v1",
     };
     let base = profile
@@ -1024,7 +1039,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_openai_models_url_supports_synthetic_and_chutes_defaults() {
+    fn resolve_openai_models_url_supports_provider_defaults() {
         let mk = |provider: &str| ResolvedLlmProviderProfile {
             alias: provider.to_string(),
             provider: provider.to_string(),
@@ -1040,6 +1055,10 @@ mod tests {
         assert_eq!(
             resolve_openai_models_url(&mk("chutes")),
             "https://llm.chutes.ai/v1/models"
+        );
+        assert_eq!(
+            resolve_openai_models_url(&mk("google")),
+            "https://generativelanguage.googleapis.com/v1beta/openai/models"
         );
     }
 }

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -795,6 +795,31 @@ pub struct OpenAiProvider {
     responses_url: String,
 }
 
+fn openai_compat_default_base(provider: &str) -> &'static str {
+    match provider.trim().to_ascii_lowercase().as_str() {
+        "openai" => "https://api.openai.com/v1",
+        "openrouter" => "https://openrouter.ai/api/v1",
+        "ollama" => "http://127.0.0.1:11434/v1",
+        "google" => "https://generativelanguage.googleapis.com/v1beta/openai",
+        "alibaba" => "https://dashscope.aliyuncs.com/compatible-mode/v1",
+        "deepseek" => "https://api.deepseek.com/v1",
+        "synthetic" => "https://api.synthetic.new/openai/v1",
+        "chutes" => "https://llm.chutes.ai/v1",
+        "moonshot" => "https://api.moonshot.cn/v1",
+        "mistral" => "https://api.mistral.ai/v1",
+        "azure" => "https://YOUR-RESOURCE.openai.azure.com/openai/deployments/YOUR-DEPLOYMENT",
+        "bedrock" => "https://bedrock-runtime.YOUR-REGION.amazonaws.com/openai/v1",
+        "zhipu" => "https://open.bigmodel.cn/api/paas/v4",
+        "minimax" => "https://api.minimax.io/v1",
+        "cohere" => "https://api.cohere.ai/compatibility/v1",
+        "tencent" => "https://api.hunyuan.cloud.tencent.com/v1",
+        "xai" => "https://api.x.ai/v1",
+        "huggingface" => "https://router.huggingface.co/v1",
+        "together" => "https://api.together.xyz/v1",
+        _ => "https://api.openai.com/v1",
+    }
+}
+
 fn resolve_openai_compat_base(provider: &str, configured_base: &str) -> String {
     let trimmed = configured_base.trim().trim_end_matches('/').to_string();
     if is_openai_codex_provider(provider) {
@@ -805,7 +830,7 @@ fn resolve_openai_compat_base(provider: &str, configured_base: &str) -> String {
     }
 
     if trimmed.is_empty() {
-        "https://api.openai.com/v1".to_string()
+        openai_compat_default_base(provider).to_string()
     } else {
         trimmed
     }
@@ -3011,6 +3036,21 @@ mod tests {
     fn test_resolve_openai_compat_base_defaults_openai() {
         let base = resolve_openai_compat_base("openai", "");
         assert_eq!(base, "https://api.openai.com/v1");
+    }
+
+    #[test]
+    fn test_resolve_openai_compat_base_defaults_google_provider() {
+        let base = resolve_openai_compat_base("google", "");
+        assert_eq!(
+            base,
+            "https://generativelanguage.googleapis.com/v1beta/openai"
+        );
+    }
+
+    #[test]
+    fn test_resolve_openai_compat_base_keeps_configured_custom_base_with_path() {
+        let base = resolve_openai_compat_base("openai", "https://integrate.api.nvidia.com/v1/");
+        assert_eq!(base, "https://integrate.api.nvidia.com/v1");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Fixes OpenAI-compatible base URL routing defaults that could send requests to the wrong endpoint when `llm_base_url` is unset for non-OpenAI providers (for example `google`).

This is a stacked PR on top of `codex/sandbox-auto-runtime-preference` and only contains issue #187 routing fixes.

Refs #187.

## Root cause
`OpenAiProvider` runtime base resolution defaulted to `https://api.openai.com/v1` for all non-codex OpenAI-compatible providers when `llm_base_url` was empty.

That meant provider presets like `google` did not get their documented default base URL at runtime.

Additionally, model listing URL resolution in `chat_commands` had incomplete provider-default mapping and could also fall back to OpenAI defaults for providers like `google`.

## Changes
1. Added provider-aware OpenAI-compatible default base mapping in `src/llm.rs`:
- New helper `openai_compat_default_base(provider)`
- `resolve_openai_compat_base` now uses provider defaults when `llm_base_url` is unset
- Preserves explicit `llm_base_url` path exactly (trim trailing slash only), so endpoints like `https://integrate.api.nvidia.com/v1` resolve correctly.

2. Expanded provider default mapping in `src/chat_commands.rs`:
- `resolve_openai_models_url` now includes the same provider-family defaults (including `google`) instead of falling back to OpenAI for most providers.

3. Added regression tests:
- `llm::tests::test_resolve_openai_compat_base_defaults_google_provider`
- `llm::tests::test_resolve_openai_compat_base_keeps_configured_custom_base_with_path`
- `chat_commands::tests::resolve_openai_models_url_supports_provider_defaults`

## Validation
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test llm::tests::test_resolve_openai_compat_base_defaults_google_provider -- --test-threads=1`
- `cargo test llm::tests::test_resolve_openai_compat_base_keeps_configured_custom_base_with_path -- --test-threads=1`
- `cargo test chat_commands::tests::resolve_openai_models_url_supports_provider_defaults -- --test-threads=1`
