### PR TITLE
fix: skip malformed tool calls with empty tool names

### DIFF
--- a/src/agent_engine.rs
+++ b/src/agent_engine.rs
@@ -2955,6 +2955,7 @@ mod tests {
                         id: "tool-empty".to_string(),
                         name: String::new(),
                         input: json!({"query": "latest news"}),
+                        thought_signature: None,
                     }],
                     stop_reason: Some("tool_use".to_string()),
                     usage: None,


### PR DESCRIPTION
## Summary
- detect malformed `tool_use` blocks with an empty `name` before tool execution
- skip execution for those malformed calls and return a structured error tool_result so the model can recover on the next turn
- add regression test that verifies empty tool names no longer surface as user-visible `Unknown tool:` failures

## Validation
- cargo fmt --all -- --check
- cargo clippy --all-targets -- -D warnings

Closes #208
