### PR TITLE
nix: harden flake build and add nixpkgs upstream guide

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,10 +55,20 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: scripts/ci/stability_smoke.sh
 
+  nix-build:
+    name: Nix Build (flake)
+    runs-on: ubuntu-latest
+    needs: [web, rust-checks]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@v19
+      - uses: DeterminateSystems/magic-nix-cache-action@v13
+      - run: nix build .#microclaw
+
   build:
     name: Build (Release)
     runs-on: ubuntu-latest
-    needs: [web, rust-checks, stability-smoke]
+    needs: [web, rust-checks, stability-smoke, nix-build]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/README.md
+++ b/README.md
@@ -542,6 +542,9 @@ Publish both installer mode (GitHub Release asset used by `install.sh`) and Home
 ./deploy.sh
 ```
 
+Nixpkgs upstream/update playbook:
+- `docs/releases/nixpkgs-upstream-guide.md`
+
 ## Setup
 
 > **New:** MicroClaw now includes an interactive setup wizard (`microclaw setup`) and will auto-launch it on first `start` when required config is missing.

--- a/README_CN.md
+++ b/README_CN.md
@@ -423,6 +423,9 @@ Todo 列表存储在 `<data_dir>/runtime/groups/{chat_id}/TODO.json`，跨会话
 ./deploy.sh
 ```
 
+Nixpkgs 上游/更新流程参考：
+- `docs/releases/nixpkgs-upstream-guide.md`
+
 ## 配置
 
 > **新功能：** 现在支持交互式问答配置（`microclaw config`），并且在 `start` 时若缺少必需配置会自动进入配置流程。

--- a/docs/releases/nixpkgs-upstream-guide.md
+++ b/docs/releases/nixpkgs-upstream-guide.md
@@ -1,0 +1,116 @@
+# Nixpkgs Upstream Guide
+
+Last reviewed: 2026-03-09
+
+This guide covers how to upstream `microclaw` to `NixOS/nixpkgs` so users get cache-backed prebuilt binaries from official Nix infrastructure.
+
+## Goal
+
+- Package `microclaw` in `nixpkgs`
+- Keep updates low-friction on each release
+- Ensure Linux + Darwin builds stay healthy
+
+## One-time Upstreaming
+
+1. Fork `NixOS/nixpkgs` and clone locally.
+2. Create package file:
+   - `pkgs/by-name/mi/microclaw/package.nix`
+3. Add entry in:
+   - `pkgs/top-level/all-packages.nix`
+4. Use this baseline expression:
+
+```nix
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  stdenv,
+  pkg-config,
+  openssl,
+  sqlite,
+  libsodium,
+  udev,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "microclaw";
+  version = "0.0.163";
+
+  src = fetchFromGitHub {
+    owner = "microclaw";
+    repo = "microclaw";
+    rev = "v${version}";
+    hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+  };
+
+  cargoHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs =
+    [
+      openssl
+      sqlite
+      libsodium
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [ udev ];
+
+  buildFeatures = lib.optionals stdenv.hostPlatform.isLinux [ "journald" "sqlite-vec" ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Multi-channel agent runtime for Telegram, Discord, Slack, and Web";
+    homepage = "https://github.com/microclaw/microclaw";
+    changelog = "https://github.com/microclaw/microclaw/releases/tag/v${version}";
+    license = licenses.mit;
+    mainProgram = "microclaw";
+    platforms = platforms.linux ++ platforms.darwin;
+    maintainers = with maintainers; [ ];
+  };
+}
+```
+
+Note: replace the placeholder `hash` and `cargoHash` with real values from build output.
+
+## Hash Update Workflow
+
+When new release `vX.Y.Z` is out:
+
+1. Bump `version` and `src.rev`.
+2. Temporarily set:
+   - `hash = lib.fakeHash;`
+   - `cargoHash = lib.fakeHash;`
+3. Run build:
+
+```sh
+nix build .#microclaw
+```
+
+4. Copy the "got: sha256-..." values from the error output into `hash` and `cargoHash`.
+5. Rebuild until it succeeds.
+
+## Validation Before Opening Nixpkgs PR
+
+- Build on Linux and Darwin (`x86_64-linux`, `aarch64-darwin` at minimum).
+- Verify executable:
+
+```sh
+result/bin/microclaw --help
+```
+
+- Confirm no Linux-only deps are used unguarded on Darwin (`udev`, `journald`).
+
+## Ongoing Maintenance Policy
+
+- Keep `flake.nix` package version aligned with `Cargo.toml`.
+- On each MicroClaw release, open/update a nixpkgs bump PR within 24h.
+- If upstream crate graph changes break nixpkgs, keep `flake` build green first, then patch nixpkgs expression.
+
+## Recommended PR Metadata
+
+- Title: `microclaw: init at <version>` (first) / `microclaw: <old> -> <new>` (bump)
+- Include:
+  - release notes link
+  - local build logs for Linux/Darwin
+  - short risk note if feature flags changed

--- a/docs/releases/pr-release-checklist.md
+++ b/docs/releases/pr-release-checklist.md
@@ -29,6 +29,8 @@ Last reviewed: 2026-03-05
 - [ ] Hook runtime sanity verified (`hooks list/info/enable/disable`).
 - [ ] Metrics pipeline verified (`/api/metrics`, `/api/metrics/history`, OTLP export if enabled).
 - [ ] Config self-check reviewed (`/api/config/self_check`) with no unaccepted `high` warnings.
+- [ ] `nix build .#microclaw` passes (Linux required; Darwin strongly recommended).
+- [ ] Nixpkgs status reviewed/updated (`docs/releases/nixpkgs-upstream-guide.md`).
 
 ## Rollback Prep
 

--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,7 @@
             openssl
             sqlite
             libsodium
+          ] ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
             udev
           ];
 
@@ -36,7 +37,7 @@
         packages = {
           microclaw = pkgs.rustPlatform.buildRustPackage {
             pname = "microclaw";
-            version = "0.0.156";
+            version = "0.0.163";
             src = ./.;
             cargoLock.lockFile = ./Cargo.lock;
             buildFeatures = pkgs.lib.optionals pkgs.stdenv.isLinux [ "journald" "sqlite-vec" ];
@@ -47,6 +48,7 @@
               openssl.out
               sqlite
               libsodium
+            ] ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
               udev
             ];
             OPENSSL_DIR = "${pkgs.openssl.dev}";


### PR DESCRIPTION
## Summary
- align `flake.nix` package version with `Cargo.toml` (`0.0.163`)
- make `udev` Linux-only in flake package/devShell so Darwin builds no longer fail
- add a CI `nix build .#microclaw` gate
- add a documented nixpkgs upstream/update playbook and wire it into release docs

## Why
Issue #219 asks to support nixpkgs packaging so users can benefit from official Nix binary cache. This PR hardens local flake reliability and adds the maintainer workflow needed to upstream and keep nixpkgs updated.

## Validation
- local: `nix --extra-experimental-features 'nix-command flakes' build .#microclaw -L` (aarch64-darwin)

Fixes #219
