### PR TITLE
fix: parse structured Gemini text parts in OpenAI-compatible responses

### DIFF
--- a/src/llm.rs
+++ b/src/llm.rs
@@ -550,34 +550,37 @@ fn process_openai_stream_event(
         return;
     };
 
-    if let Some(piece) = delta.get("content").and_then(|t| t.as_str()) {
+    if let Some(piece) = delta.get("content").and_then(extract_text_from_oai_value) {
         if !piece.is_empty() {
-            text.push_str(piece);
+            text.push_str(&piece);
             if let Some(tx) = text_tx {
-                let _ = tx.send(piece.to_string());
+                let _ = tx.send(piece);
             }
         }
     }
 
     if let Some(piece) = delta
         .get("thought")
-        .and_then(|t| t.as_str())
-        .or_else(|| delta.get("thinking").and_then(|t| t.as_str()))
+        .and_then(extract_text_from_oai_value)
+        .or_else(|| delta.get("thinking").and_then(extract_text_from_oai_value))
     {
         if !piece.is_empty() {
             if reasoning_text.is_empty() {
                 debug!("AI started generating thinking/thought");
             }
-            reasoning_text.push_str(piece);
+            reasoning_text.push_str(&piece);
         }
     }
 
-    if let Some(piece) = delta.get("reasoning_content").and_then(|t| t.as_str()) {
+    if let Some(piece) = delta
+        .get("reasoning_content")
+        .and_then(extract_text_from_oai_value)
+    {
         if !piece.is_empty() {
             if reasoning_text.is_empty() {
                 debug!("AI started generating reasoning_content");
             }
-            reasoning_text.push_str(piece);
+            reasoning_text.push_str(&piece);
         }
     }
 
@@ -594,9 +597,8 @@ fn process_openai_stream_event(
                 None
             };
 
-            let index = index.unwrap_or_else(|| {
-                tool_calls.keys().last().map(|last| last + 1).unwrap_or(0)
-            });
+            let index =
+                index.unwrap_or_else(|| tool_calls.keys().last().map(|last| last + 1).unwrap_or(0));
 
             let entry = tool_calls.entry(index).or_default();
             if let Some(id) = tc.get("id").and_then(|v| v.as_str()) {
@@ -696,7 +698,8 @@ fn build_stream_response(
     let mut normalized_stop_reason = normalize_stop_reason(stop_reason);
     if !tool_blocks.is_empty() {
         normalized_stop_reason = Some("tool_use".to_string());
-    } else if normalized_stop_reason.as_deref() == Some("tool_use") && !has_tool_use_block(&content) {
+    } else if normalized_stop_reason.as_deref() == Some("tool_use") && !has_tool_use_block(&content)
+    {
         warn!("Downgrading stop_reason=tool_use to end_turn because no tool_calls were parsed");
         normalized_stop_reason = Some("end_turn".into());
     }
@@ -1061,6 +1064,41 @@ where
     Ok(Option::<Vec<OaiChoice>>::deserialize(deserializer)?.unwrap_or_default())
 }
 
+fn deserialize_optional_oai_text<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+    Ok(value.and_then(|v| extract_text_from_oai_value(&v)))
+}
+
+fn extract_text_from_oai_value(value: &serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::Null => None,
+        serde_json::Value::String(text) => Some(text.clone()),
+        serde_json::Value::Array(items) => {
+            let combined = items
+                .iter()
+                .filter_map(extract_text_from_oai_value)
+                .collect::<Vec<_>>()
+                .join("");
+            if combined.is_empty() {
+                None
+            } else {
+                Some(combined)
+            }
+        }
+        serde_json::Value::Object(map) => map
+            .get("text")
+            .and_then(|v| v.as_str())
+            .map(|v| v.to_string())
+            .or_else(|| map.get("content").and_then(extract_text_from_oai_value))
+            .or_else(|| map.get("parts").and_then(extract_text_from_oai_value))
+            .or_else(|| map.get("value").and_then(extract_text_from_oai_value)),
+        _ => None,
+    }
+}
+
 #[derive(Debug, Deserialize)]
 struct OaiChoice {
     message: OaiMessage,
@@ -1069,7 +1107,9 @@ struct OaiChoice {
 
 #[derive(Debug, Deserialize)]
 struct OaiMessage {
+    #[serde(default, deserialize_with = "deserialize_optional_oai_text")]
     content: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_optional_oai_text")]
     reasoning_content: Option<String>,
     tool_calls: Option<Vec<OaiToolCall>>,
 }
@@ -2213,7 +2253,10 @@ mod tests {
         }];
         let out = translate_messages_to_oai("", &msgs);
         let tc = out[0]["tool_calls"].as_array().unwrap();
-        assert_eq!(tc[0]["extra_content"]["google"]["thought_signature"], "sig_abc");
+        assert_eq!(
+            tc[0]["extra_content"]["google"]["thought_signature"],
+            "sig_abc"
+        );
     }
 
     #[test]
@@ -2655,6 +2698,19 @@ mod tests {
     }
 
     #[test]
+    fn test_translate_oai_response_accepts_structured_content_arrays() {
+        let raw = r#"{"choices":[{"message":{"content":[{"type":"text","text":"Hello "},{"type":"text","text":"Gemini"}],"reasoning_content":[{"type":"text","text":"plan "},{"type":"text","text":"steps"}],"tool_calls":null},"finish_reason":"stop"}],"usage":null}"#;
+        let oai: OaiResponse = serde_json::from_str(raw).unwrap();
+        let resp = translate_oai_response(oai);
+        match &resp.content[0] {
+            ResponseContentBlock::Text { text } => {
+                assert_eq!(text, "<thought>\nplan steps\n</thought>\n\nHello Gemini")
+            }
+            _ => panic!("Expected Text"),
+        }
+    }
+
+    #[test]
     fn test_translate_oai_response_reasoning_only() {
         let oai = OaiResponse {
             choices: vec![OaiChoice {
@@ -2735,6 +2791,32 @@ mod tests {
         assert_eq!(call.name, "bash");
         assert_eq!(call.input_json, r#"{"command":"ls"}"#);
         assert_eq!(call.thought_signature.as_deref(), Some("sig_123"));
+    }
+
+    #[test]
+    fn test_process_openai_stream_event_accepts_structured_delta_content() {
+        let data = r#"{"choices":[{"delta":{"content":[{"type":"text","text":"Hello "},{"type":"text","text":"Gemini"}],"reasoning_content":[{"type":"text","text":"plan"},{"type":"text","text":" more"}]}}],"usage":null}"#;
+        let mut text = String::new();
+        let mut reasoning_text = String::new();
+        let mut stop_reason = None;
+        let mut usage = None;
+        let mut tool_calls = std::collections::BTreeMap::new();
+
+        process_openai_stream_event(
+            data,
+            None,
+            &mut text,
+            &mut reasoning_text,
+            &mut stop_reason,
+            &mut usage,
+            &mut tool_calls,
+        );
+
+        assert_eq!(text, "Hello Gemini");
+        assert_eq!(reasoning_text, "plan more");
+        assert_eq!(stop_reason, None);
+        assert!(usage.is_none());
+        assert!(tool_calls.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- accept structured text-part arrays/objects for OpenAI-compatible `content` and `reasoning_content` fields
- apply the same extraction logic to streamed deltas so Gemini responses are rendered correctly
- add regression tests for structured non-stream and stream payloads

## Verification
- cargo test test_translate_oai_response_accepts_structured_content_arrays -- --nocapture
- cargo test test_process_openai_stream_event_accepts_structured_delta_content -- --nocapture
- cargo test test_translate_oai_response_reasoning_content_and_tool_calls -- --nocapture
- cargo clippy --all-targets -- -D warnings

Closes #237