### PR TITLE
[codex] add official docker image release flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,20 @@ jobs:
             echo "website workspace not present in this checkout; skipping"
           fi
 
+  docker-build:
+    name: Docker Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          tags: microclaw:test
+          cache-from: type=gha,scope=ci-docker-build
+          cache-to: type=gha,mode=max,scope=ci-docker-build
+
   security-audit:
     name: Security Audit
     runs-on: ubuntu-latest
@@ -90,7 +104,7 @@ jobs:
   build:
     name: Build (Release)
     runs-on: ubuntu-latest
-    needs: [web, security-audit, rust-ubuntu, rust-macos, stability-smoke]
+    needs: [web, docker-build, security-audit, rust-ubuntu, rust-macos, stability-smoke]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 env:
   CARGO_TERM_COLOR: always
@@ -34,7 +35,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           CI_WAIT_TIMEOUT_SECONDS: "900"
           CI_WAIT_INTERVAL_SECONDS: "30"
-          REQUIRED_CI_JOBS_JSON: '["Web And Docs Build","Security Audit","Rust (ubuntu-latest)","Rust (macos-latest)","Stability Smoke"]'
+          REQUIRED_CI_JOBS_JSON: '["Web And Docs Build","Docker Build","Security Audit","Rust (ubuntu-latest)","Rust (macos-latest)","Stability Smoke"]'
         shell: bash
         run: |
           TARGET_SHA="$(git rev-parse HEAD)"
@@ -208,6 +209,88 @@ jobs:
           name: ${{ matrix.label }}
           path: ${{ env.ASSET_NAME }}
           if-no-files-found: error
+
+  publish-container:
+    name: Publish Container Image
+    runs-on: ubuntu-latest
+    needs: verify-ci
+    env:
+      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref_name }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    steps:
+      - name: Checkout tag commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Prepare image names
+        id: image_names
+        shell: bash
+        run: |
+          {
+            echo "images<<EOF"
+            echo "ghcr.io/${GITHUB_REPOSITORY}"
+            if [[ -n "${DOCKERHUB_USERNAME}" && -n "${DOCKERHUB_TOKEN}" ]]; then
+              echo "docker.io/microclaw/microclaw"
+            fi
+            echo "EOF"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Note Docker Hub publish status
+        shell: bash
+        run: |
+          if [[ -n "${DOCKERHUB_USERNAME}" && -n "${DOCKERHUB_TOKEN}" ]]; then
+            echo "Docker Hub publishing enabled for docker.io/microclaw/microclaw"
+          else
+            echo "Docker Hub publishing secrets are not configured; publishing GHCR only."
+          fi
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.image_names.outputs.images }}
+          tags: |
+            type=semver,pattern={{version}},value=${{ env.RELEASE_TAG }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ env.RELEASE_TAG }}
+            type=semver,pattern={{major}},value=${{ env.RELEASE_TAG }}
+            type=raw,value=latest
+          labels: |
+            org.opencontainers.image.title=MicroClaw
+            org.opencontainers.image.description=Multi-channel agent runtime for Telegram, Discord, Web, and more.
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Log in to Docker Hub
+        if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=release-container
+          cache-to: type=gha,mode=max,scope=release-container
 
   publish-assets:
     name: Upload to GitHub Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,13 @@ The format is loosely based on Keep a Changelog. Dates use UTC.
 - CI coverage and dependency-audit gates
 - release packaging coverage for macOS artifacts and checksum publication
 - stronger config self-check coverage for risky execution settings
+- official container image release automation for GHCR, with optional Docker Hub mirroring when repository credentials are configured
 
 ### Changed
 
 - CI now builds the website docs alongside the web UI
 - release process documentation now points to explicit support and release-policy artifacts
+- Docker builds now compile embedded web assets inside the image build and default the runtime image to `microclaw start`
 
 ## 0.1.12
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,22 @@
 # syntax=docker/dockerfile:1
 
-# Stage 1: Build tools
-FROM rust:1.88-slim-bookworm AS chef
+ARG NODE_VERSION=20
+ARG RUST_VERSION=1.93.1
 
-# Install build dependencies
+# Stage 1: Build embedded web assets so the binary does not depend on checked-in dist files.
+FROM node:${NODE_VERSION}-bookworm-slim AS web-builder
+
+WORKDIR /usr/src/microclaw/web
+
+COPY web/package.json web/package-lock.json ./
+RUN npm ci
+
+COPY web ./
+RUN npm run build
+
+# Stage 2: Build tools
+FROM rust:${RUST_VERSION}-slim-bookworm AS chef
+
 RUN apt-get update && apt-get install -y \
     pkg-config \
     libssl-dev \
@@ -13,46 +26,39 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /usr/src/microclaw
 
-# Install cargo-chef to improve dependency layer caching
 RUN cargo install cargo-chef --locked
 
-# Stage 2: Prepare dependency recipe
+# Stage 3: Prepare dependency recipe
 FROM chef AS planner
 
 COPY . .
 RUN cargo chef prepare --recipe-path recipe.json
 
-# Stage 3: Build
+# Stage 4: Build
 FROM chef AS builder
 
 COPY --from=planner /usr/src/microclaw/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
 
 COPY . .
+COPY --from=web-builder /usr/src/microclaw/web/dist ./web/dist
 
-# Build the binary in release mode
 RUN cargo build --release --locked --bin microclaw
 
-# Stage 4: Run
+# Stage 5: Run
 FROM debian:bookworm-slim
 
-# Install runtime certificates and libraries
 RUN apt-get update && apt-get install -y \
     ca-certificates \
     libssl3 \
     libsqlite3-0 \
     && rm -rf /var/lib/apt/lists/*
 
-# Run as non-root by default
 RUN useradd --create-home --home-dir /home/microclaw --uid 10001 --shell /usr/sbin/nologin microclaw
 
 WORKDIR /app
 
-# Copy the compiled binary
 COPY --from=builder /usr/src/microclaw/target/release/microclaw /usr/local/bin/
-
-# Copy necessary runtime directories
-COPY --from=builder /usr/src/microclaw/web ./web
 COPY --from=builder /usr/src/microclaw/skills ./skills
 COPY --from=builder /usr/src/microclaw/scripts ./scripts
 
@@ -60,6 +66,9 @@ RUN mkdir -p /home/microclaw/.microclaw /app/tmp \
     && chown -R microclaw:microclaw /home/microclaw /app
 
 ENV HOME=/home/microclaw
+EXPOSE 10961
+
 USER microclaw
 
-CMD ["microclaw"]
+ENTRYPOINT ["microclaw"]
+CMD ["start"]

--- a/README.md
+++ b/README.md
@@ -155,6 +155,32 @@ brew tap microclaw/tap
 brew install microclaw
 ```
 
+### Docker image
+
+Release tags publish an official container image to:
+
+- `ghcr.io/microclaw/microclaw:latest`
+- `ghcr.io/microclaw/microclaw:<version>`
+- `docker.io/microclaw/microclaw:latest` when Docker Hub publishing credentials are configured for the repository
+
+Run the official image with your local config and data mounts:
+
+```sh
+docker run --rm -it \
+  -p 127.0.0.1:10961:10961 \
+  -v "$(pwd)/microclaw.config.yaml:/app/microclaw.config.yaml:ro" \
+  -v "$(pwd)/data:/home/microclaw/.microclaw" \
+  -v "$(pwd)/tmp:/app/tmp" \
+  ghcr.io/microclaw/microclaw:latest
+```
+
+The image entrypoint is `microclaw`, so you can override the command directly:
+
+```sh
+docker run --rm ghcr.io/microclaw/microclaw:latest doctor
+docker run --rm ghcr.io/microclaw/microclaw:latest version
+```
+
 ### From source
 
 ```sh

--- a/README_CN.md
+++ b/README_CN.md
@@ -155,6 +155,32 @@ brew tap microclaw/tap
 brew install microclaw
 ```
 
+### Docker 镜像
+
+Release tag 会发布官方容器镜像到：
+
+- `ghcr.io/microclaw/microclaw:latest`
+- `ghcr.io/microclaw/microclaw:<版本号>`
+- `docker.io/microclaw/microclaw:latest`，前提是仓库已配置 Docker Hub 发布凭据
+
+使用本地配置和数据目录挂载运行官方镜像：
+
+```sh
+docker run --rm -it \
+  -p 127.0.0.1:10961:10961 \
+  -v "$(pwd)/microclaw.config.yaml:/app/microclaw.config.yaml:ro" \
+  -v "$(pwd)/data:/home/microclaw/.microclaw" \
+  -v "$(pwd)/tmp:/app/tmp" \
+  ghcr.io/microclaw/microclaw:latest
+```
+
+镜像入口是 `microclaw`，因此可以直接覆盖子命令：
+
+```sh
+docker run --rm ghcr.io/microclaw/microclaw:latest doctor
+docker run --rm ghcr.io/microclaw/microclaw:latest version
+```
+
 ### 从源码构建
 
 ```sh

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
       context: .
       dockerfile: Dockerfile
     container_name: microclaw
-    command: ["microclaw", "start"]
+    command: ["start"]
     stdin_open: true
     tty: true
     init: true

--- a/docs/releases/pr-release-checklist.md
+++ b/docs/releases/pr-release-checklist.md
@@ -34,6 +34,7 @@ Last reviewed: 2026-03-05
 - [ ] Metrics pipeline verified (`/api/metrics`, `/api/metrics/history`, OTLP export if enabled).
 - [ ] Config self-check reviewed (`/api/config/self_check`) with no unaccepted `high` warnings.
 - [ ] macOS, Linux, and Windows release assets are present and checksummed.
+- [ ] Official container image tags are published and pull successfully (`ghcr.io/microclaw/microclaw`, Docker Hub mirror if enabled).
 - [ ] `nix build .#microclaw` passes (Linux required; Darwin strongly recommended).
 - [ ] Nixpkgs status reviewed/updated (`docs/releases/nixpkgs-upstream-guide.md`).
 

--- a/docs/releases/release-policy.md
+++ b/docs/releases/release-policy.md
@@ -9,6 +9,7 @@ Each release should have:
 - green required CI jobs
 - generated release notes
 - packaged binaries for supported platforms
+- official container images for Linux (`linux/amd64`, `linux/arm64`)
 - upgrade notes when migrations or config changes are involved
 - rollback instructions recorded in the PR or release checklist
 
@@ -35,6 +36,7 @@ Release candidates should satisfy:
 - `node scripts/generate_docs_artifacts.mjs --check`
 - security dependency audit
 - release asset packaging smoke
+- container image build/publish smoke
 
 ## Rollback Standard
 


### PR DESCRIPTION
Fixes #274.

## Summary

This PR adds a first-party container release path for MicroClaw so releases no longer stop at standalone binaries. The repository already had a `Dockerfile`, but there was no CI validation for it and no release automation to publish an official image that users could pull directly.

For users, the practical effect was that Docker support existed only as a source-build path. Anyone who wanted to run MicroClaw in a container still had to clone the repository and build locally, which is the opposite of what issue #274 is asking for.

## Root cause

The gap had two parts. First, the existing release workflow only packaged GitHub release binaries and never built or pushed OCI images. Second, the `Dockerfile` depended on checked-in web assets instead of building them as part of the image build, which made container builds less deterministic and easier to drift from the actual web UI source.

## What changed

The Docker build is now deterministic and release-ready. The `Dockerfile` builds the embedded web assets in a dedicated Node stage, aligns the Rust toolchain with the repository's `rust-toolchain.toml`, trims the runtime image to the binary plus required runtime assets, and defaults the container to `microclaw start` via `ENTRYPOINT`/`CMD`. The local compose file was adjusted to match the new entrypoint shape.

CI now includes a dedicated `Docker Build` job so container regressions are caught in pull requests instead of being discovered at release time. The tagged release workflow now publishes a multi-arch image to GHCR and, when `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` are configured in repository secrets, mirrors the same release tags to Docker Hub. Release docs and checklist entries were updated so image publication is part of the normal release contract.

## Validation

I validated the change locally with:

- `cargo fmt --all --check`
- `cargo test`
- `npm --prefix web ci`
- `npm --prefix web run build`
- `docker build -t microclaw:test .`
- `docker run --rm microclaw:test version`

## Follow-up

Docker Hub publication is implemented in the workflow, but it still depends on repository-level secrets being configured in GitHub Actions. Without those secrets, releases will still publish the official GHCR image and skip the Docker Hub mirror explicitly.
