### PR TITLE
[codex] discourage invented file paths in tool prompts

### DIFF
--- a/src/agent_engine.rs
+++ b/src/agent_engine.rs
@@ -2003,8 +2003,9 @@ Built-in execution playbook:
 - Only ask follow-up questions first when required parameters are missing or when the action has side effects, permissions, cost, or elevated risk.
 - Apply the same behavior across Telegram/Discord/Web unless a tool returns a channel-specific error.
 - Do not answer with "I can't from this runtime" unless a concrete tool attempt failed in this turn.
-- Always prefer absolute paths for files passed between tools (especially attachment_path).
-- For bash/file tools, treat the current chat working directory as the default workspace. For temporary files, clones, and build artifacts, use the current chat working directory's `tmp/` subdirectory. Do not use absolute `/tmp/...` paths.
+- For bash/file tools (`bash`, `read_file`, `write_file`, `edit_file`, `glob`, `grep`), treat the current chat working directory as the default workspace and prefer relative paths rooted there.
+- Do not invent machine-specific absolute paths such as `/home/...`, `/Users/...`, or `C:\...`. Only use an absolute path when the user explicitly provided it, a tool returned it in this turn, or a tool input explicitly requires one (for example `attachment_path`).
+- For temporary files, clones, and build artifacts, use the current chat working directory's `tmp/` subdirectory. Do not use absolute `/tmp/...` paths.
 - For coding tasks, follow this loop: inspect code (`read_file`/`grep`/`glob`) -> edit (`edit_file`/`write_file`) -> validate (`bash` tests/build) -> summarize concrete changes/results.
 - If you will call any tool or activate any skill in this turn, you must start by calling todo_write to create a concise task list before the first tool/skill call.
 - This requirement includes activate_skill: plan the work in todo_write first, then activate and execute.
@@ -2014,9 +2015,9 @@ Built-in execution playbook:
 - After each major step, update todo_write to reflect real progress (not planned progress).
 - Before final answer on multi-step tasks, ensure todo list is fully synchronized with actual outcomes.
 - For "send current desktop screenshot" style requests, use this sequence:
-  1) capture via bash to an absolute path
+  1) capture via bash to a file under the current chat working directory
   2) verify file exists
-  3) send via send_message with attachment_path
+  3) send via send_message with attachment_path using the verified file path
   4) only then confirm success
 - If step 1-3 fails, report the exact failed step and error, then propose a retry.
 "#
@@ -3316,6 +3317,16 @@ mod tests {
         assert!(prompt.contains("current chat working directory"));
         assert!(prompt.contains("use the current chat working directory's `tmp/` subdirectory"));
         assert!(prompt.contains("Do not use absolute `/tmp/...` paths"));
+    }
+
+    #[test]
+    fn test_build_system_prompt_discourages_invented_machine_paths() {
+        let prompt = super::build_system_prompt("testbot", "telegram", "", 42, "", "UTC", None);
+        assert!(prompt.contains("prefer relative paths rooted there"));
+        assert!(prompt.contains("Do not invent machine-specific absolute paths"));
+        assert!(prompt.contains("/home/..."));
+        assert!(prompt.contains("/Users/..."));
+        assert!(prompt.contains("attachment_path"));
     }
 
     #[test]

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -159,7 +159,7 @@ impl Tool for BashTool {
     fn definition(&self) -> ToolDefinition {
         ToolDefinition {
             name: "bash".into(),
-            description: "Execute a bash command and return the output. IMPORTANT: You must CALL this tool (not write it as text) to run a command. Use for running shell commands, scripts, or system operations. Use relative paths or the current chat working directory's tmp/ subdirectory instead of absolute /tmp paths.".into(),
+            description: "Execute a bash command and return the output. IMPORTANT: You must CALL this tool (not write it as text) to run a command. Use for running shell commands, scripts, or system operations. Prefer relative paths rooted in the current chat working directory, and use its tmp/ subdirectory instead of absolute /tmp paths. Do not invent machine-specific absolute paths like /home/... or /Users/... unless the user or a tool already provided them.".into(),
             input_schema: schema_object(
                 json!({
                     "command": {
@@ -419,7 +419,10 @@ mod tests {
         assert_eq!(tool.name(), "bash");
         let def = tool.definition();
         assert_eq!(def.name, "bash");
-        assert!(!def.description.is_empty());
+        assert!(def
+            .description
+            .contains("Prefer relative paths rooted in the current chat working directory"));
+        assert!(def.description.contains("/home/... or /Users/..."));
         assert!(def.input_schema["properties"]["command"].is_object());
     }
 

--- a/src/tools/edit_file.rs
+++ b/src/tools/edit_file.rs
@@ -38,12 +38,12 @@ impl Tool for EditFileTool {
     fn definition(&self) -> ToolDefinition {
         ToolDefinition {
             name: "edit_file".into(),
-            description: "Edit a file by replacing an exact string match with new content. The old_string must be unique in the file.".into(),
+            description: "Edit a file by replacing an exact string match with new content. The old_string must be unique in the file. Prefer paths relative to the current chat working directory; do not invent machine-specific absolute paths unless the user or a tool already provided them.".into(),
             input_schema: schema_object(
                 json!({
                     "path": {
                         "type": "string",
-                        "description": "The file path to edit"
+                        "description": "The file path to edit, usually relative to the current chat working directory"
                     },
                     "old_string": {
                         "type": "string",
@@ -115,6 +115,19 @@ impl Tool for EditFileTool {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn test_edit_file_definition_prefers_relative_paths() {
+        let tool = EditFileTool::new(".");
+        let def = tool.definition();
+        assert!(def
+            .description
+            .contains("Prefer paths relative to the current chat working directory"));
+        assert_eq!(
+            def.input_schema["properties"]["path"]["description"].as_str(),
+            Some("The file path to edit, usually relative to the current chat working directory")
+        );
+    }
 
     fn setup_file(content: &str) -> (std::path::PathBuf, std::path::PathBuf) {
         let dir = std::env::temp_dir().join(format!("microclaw_ef_{}", uuid::Uuid::new_v4()));

--- a/src/tools/read_file.rs
+++ b/src/tools/read_file.rs
@@ -38,12 +38,12 @@ impl Tool for ReadFileTool {
     fn definition(&self) -> ToolDefinition {
         ToolDefinition {
             name: "read_file".into(),
-            description: "Read the contents of a file at the given path. Returns the file content with line numbers.".into(),
+            description: "Read the contents of a file at the given path. Returns the file content with line numbers. Prefer paths relative to the current chat working directory; do not invent machine-specific absolute paths unless the user or a tool already provided them.".into(),
             input_schema: schema_object(
                 json!({
                     "path": {
                         "type": "string",
-                        "description": "The file path to read"
+                        "description": "The file path to read, usually relative to the current chat working directory"
                     },
                     "offset": {
                         "type": "integer",
@@ -107,6 +107,19 @@ impl Tool for ReadFileTool {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn test_read_file_definition_prefers_relative_paths() {
+        let tool = ReadFileTool::new(".");
+        let def = tool.definition();
+        assert!(def
+            .description
+            .contains("Prefer paths relative to the current chat working directory"));
+        assert_eq!(
+            def.input_schema["properties"]["path"]["description"].as_str(),
+            Some("The file path to read, usually relative to the current chat working directory")
+        );
+    }
 
     #[tokio::test]
     async fn test_read_file_success() {

--- a/src/tools/write_file.rs
+++ b/src/tools/write_file.rs
@@ -38,12 +38,12 @@ impl Tool for WriteFileTool {
     fn definition(&self) -> ToolDefinition {
         ToolDefinition {
             name: "write_file".into(),
-            description: "Write content to a file. Creates the file and any parent directories if they don't exist. Overwrites existing content.".into(),
+            description: "Write content to a file. Creates the file and any parent directories if they don't exist. Overwrites existing content. Prefer paths relative to the current chat working directory; do not invent machine-specific absolute paths unless the user or a tool already provided them.".into(),
             input_schema: schema_object(
                 json!({
                     "path": {
                         "type": "string",
-                        "description": "The file path to write to"
+                        "description": "The file path to write to, usually relative to the current chat working directory"
                     },
                     "content": {
                         "type": "string",
@@ -111,6 +111,19 @@ impl Tool for WriteFileTool {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn test_write_file_definition_prefers_relative_paths() {
+        let tool = WriteFileTool::new(".");
+        let def = tool.definition();
+        assert!(def
+            .description
+            .contains("Prefer paths relative to the current chat working directory"));
+        assert_eq!(
+            def.input_schema["properties"]["path"]["description"].as_str(),
+            Some("The file path to write to, usually relative to the current chat working directory")
+        );
+    }
 
     #[tokio::test]
     async fn test_write_file_success() {


### PR DESCRIPTION
## Summary
MicroClaw's prompt guidance for file handling was internally inconsistent. The system prompt told the model to prefer absolute paths for files passed between tools, while other prompt and tool descriptions told it to work from the current chat working directory and avoid absolute `/tmp/...` usage. In practice this pushed the model toward inventing machine-specific paths such as `/home/ws-user/...` even when the runtime was operating elsewhere.

For users, the effect was noisy and avoidable tool failures. `bash` commands tried to create directories in nonexistent or unsupported locations, and file tools such as `write_file` attempted to access fabricated absolute paths that then failed path-guard checks. The task could still be marked done if a later attempt succeeded, but the agent wasted iterations and produced misleading logs along the way.

The root cause was conflicting prompt policy rather than a tool execution bug. The agent prompt explicitly encouraged absolute paths in one section, and the file-tool schemas were too generic to reinforce the actual workspace model. That combination left enough ambiguity for the model to hallucinate host-specific paths.

This change makes the path policy consistent across the system prompt and file-related tool definitions. The agent is now instructed to prefer relative paths rooted in the current chat working directory for `bash`, `read_file`, `write_file`, `edit_file`, `glob`, and `grep`. It is also told not to invent machine-specific absolute paths such as `/home/...`, `/Users/...`, or `C:\...`, and to use absolute paths only when the user provided one, a tool returned one in the current turn, or a tool input explicitly requires one such as `attachment_path`. The screenshot playbook was updated to match the same rule so it no longer nudges the agent toward arbitrary absolute paths.

The tool definitions for `bash`, `read_file`, `write_file`, and `edit_file` now repeat the same guidance in their descriptions and path field docs, which gives the model a second consistent source of truth when it is deciding how to call a tool. Regression tests were added to lock in both the prompt wording and the tool-schema wording.

## Validation
- `cargo test invented_machine_paths`
- `cargo test prefers_relative_paths`
- `cargo test bash_tool_name_and_definition`
