### PR TITLE
feat(web): refactor ws methods and implement dynamic sessions.list

### DIFF
--- a/src/web.rs
+++ b/src/web.rs
@@ -4673,20 +4673,20 @@ commands:
         for (request_id, method, params) in [
             (
                 "setting-1",
-                "session_setLabel",
+                "sessions.setLabel",
                 json!({"sessionKey":"main","label":"Ops"}),
             ),
             (
                 "send-1",
-                "sessions_send",
+                "sessions.send",
                 json!({"sessionKey":"main","message":"continue"}),
             ),
             (
                 "spawn-1",
-                "sessions_spawn",
+                "sessions.spawn",
                 json!({"task":"spawn from mission control","label":"worker"}),
             ),
-            ("delete-1", "session_delete", json!({"sessionKey":"main"})),
+            ("delete-1", "sessions.delete", json!({"sessionKey":"main"})),
         ] {
             ws.send(tokio_tungstenite::tungstenite::Message::Text(
                 json!({
@@ -4714,7 +4714,7 @@ commands:
                 Some(true),
                 "{method}"
             );
-            if method == "sessions_send" {
+            if method == "sessions.send" {
                 let mut saw_final = false;
                 for _ in 0..12 {
                     let candidate = recv_ws_json(&mut ws).await;
@@ -4740,6 +4740,172 @@ commands:
                 assert!(saw_final, "sessions_send should emit a final chat event");
             }
         }
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn test_ws_sessions_list_returns_filtered_sessions() {
+        let web_state = test_web_state(Box::new(DummyLlm), WebLimits::default());
+        seed_test_api_key(&web_state, "ws-list-secret").await;
+        let (addr, server) = spawn_test_server(build_router(web_state.clone())).await;
+
+        let app = build_router(web_state.clone());
+
+        // Seed a session that should NOT be returned
+        let req1 = Request::builder()
+            .method("POST")
+            .uri("/api/send")
+            .header("authorization", "Bearer ws-list-secret")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"session_key":"other:123","sender_name":"u","message":"seed"}"#,
+            ))
+            .unwrap();
+        app.clone().oneshot(req1).await.unwrap();
+
+        // Seed a session that SHOULD be returned
+        let req2 = Request::builder()
+            .method("POST")
+            .uri("/api/send")
+            .header("authorization", "Bearer ws-list-secret")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"session_key":"chatclaw:microclaw:456","sender_name":"u","message":"seed"}"#,
+            ))
+            .unwrap();
+        app.clone().oneshot(req2).await.unwrap();
+
+        let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://{addr}/"))
+            .await
+            .unwrap();
+        let _ = recv_ws_json(&mut ws).await;
+        ws.send(tokio_tungstenite::tungstenite::Message::Text(
+            json!({
+                "type": "req",
+                "id": "connect-1",
+                "method": "connect",
+                "params": {
+                    "minProtocol": 3,
+                    "maxProtocol": 3,
+                    "auth": { "token": "ws-list-secret" }
+                }
+            })
+            .to_string(),
+        ))
+        .await
+        .unwrap();
+        let _ = recv_ws_json(&mut ws).await;
+
+        ws.send(tokio_tungstenite::tungstenite::Message::Text(
+            json!({
+                "type": "req",
+                "id": "list-1",
+                "method": "sessions.list",
+                "params": {
+                    "agentId": "chatclaw:microclaw"
+                }
+            })
+            .to_string(),
+        ))
+        .await
+        .unwrap();
+
+        let res = loop {
+            let candidate = recv_ws_json(&mut ws).await;
+            if candidate.get("type").and_then(|v| v.as_str()) != Some("res") {
+                continue;
+            }
+            if candidate.get("id").and_then(|v| v.as_str()) != Some("list-1") {
+                continue;
+            }
+            break candidate;
+        };
+
+        assert_eq!(res.get("ok").and_then(|v| v.as_bool()), Some(true));
+
+        let sessions = res
+            .pointer("/payload/sessions")
+            .and_then(|v| v.as_array())
+            .unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(
+            sessions[0].get("session_key").and_then(|v| v.as_str()),
+            Some("chatclaw:microclaw:456")
+        );
+
+        // Test with search term
+        ws.send(tokio_tungstenite::tungstenite::Message::Text(
+            json!({
+                "type": "req",
+                "id": "list-search",
+                "method": "sessions.list",
+                "params": {
+                    "search": "123"
+                }
+            })
+            .to_string(),
+        ))
+        .await
+        .unwrap();
+
+        let res_search = loop {
+            let candidate = recv_ws_json(&mut ws).await;
+            if candidate.get("type").and_then(|v| v.as_str()) != Some("res") {
+                continue;
+            }
+            if candidate.get("id").and_then(|v| v.as_str()) != Some("list-search") {
+                continue;
+            }
+            break candidate;
+        };
+
+        assert_eq!(res_search.get("ok").and_then(|v| v.as_bool()), Some(true));
+
+        let sessions_search = res_search
+            .pointer("/payload/sessions")
+            .and_then(|v| v.as_array())
+            .unwrap();
+        assert_eq!(sessions_search.len(), 1);
+        assert_eq!(
+            sessions_search[0]
+                .get("session_key")
+                .and_then(|v| v.as_str()),
+            Some("other:123")
+        );
+
+        // Test without filter
+        ws.send(tokio_tungstenite::tungstenite::Message::Text(
+            json!({
+                "type": "req",
+                "id": "list-2",
+                "method": "sessions.list",
+                "params": {}
+            })
+            .to_string(),
+        ))
+        .await
+        .unwrap();
+
+        let res2 = loop {
+            let candidate = recv_ws_json(&mut ws).await;
+            if candidate.get("type").and_then(|v| v.as_str()) != Some("res") {
+                continue;
+            }
+            if candidate.get("id").and_then(|v| v.as_str()) != Some("list-2") {
+                continue;
+            }
+            break candidate;
+        };
+
+        assert_eq!(res2.get("ok").and_then(|v| v.as_bool()), Some(true));
+
+        let sessions2 = res2
+            .pointer("/payload/sessions")
+            .and_then(|v| v.as_array())
+            .unwrap();
+        // Since we seeded two sessions, it should return both without filter
+        assert_eq!(sessions2.len(), 2);
 
         server.abort();
     }
@@ -4800,12 +4966,12 @@ commands:
         for (request_id, method, params) in [
             (
                 "label-1",
-                "session_setLabel",
+                "sessions.setLabel",
                 json!({"sessionKey":"main","label":"Ops"}),
             ),
             (
                 "thinking-1",
-                "session_setThinking",
+                "sessions.setThinking",
                 json!({"sessionKey":"main","level":"high"}),
             ),
         ] {
@@ -4946,7 +5112,7 @@ commands:
             json!({
                 "type": "req",
                 "id": "kill-1",
-                "method": "sessions_kill",
+                "method": "sessions.kill",
                 "params": { "sessionKey": session_key }
             })
             .to_string(),

--- a/src/web/ws.rs
+++ b/src/web/ws.rs
@@ -97,6 +97,15 @@ struct SessionsSendParams {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+struct SessionsListParams {
+    #[serde(default)]
+    agent_id: Option<String>,
+    #[serde(default)]
+    search: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct SessionSettingParams {
     session_key: String,
     #[serde(flatten)]
@@ -132,16 +141,16 @@ fn setting_value(
 fn build_session_settings_update(method: &str, params: &SessionSettingParams) -> SessionSettings {
     let mut settings = SessionSettings::default();
     match method {
-        "session_setLabel" => {
+        "sessions.setLabel" => {
             settings.label = setting_value(&params.extra, &["label", "value"]);
         }
-        "session_setThinking" => {
+        "sessions.setThinking" => {
             settings.thinking_level = setting_value(&params.extra, &["level", "value"]);
         }
-        "session_setVerbose" => {
+        "sessions.setVerbose" => {
             settings.verbose_level = setting_value(&params.extra, &["level", "value"]);
         }
-        "session_setReasoning" => {
+        "sessions.setReasoning" => {
             settings.reasoning_level = setting_value(&params.extra, &["level", "value"]);
         }
         _ => {}
@@ -496,14 +505,15 @@ async fn process_connect_frame(
                     "status",
                     "chat.send",
                     "chat.history",
-                    "session_delete",
-                    "sessions_send",
-                    "sessions_kill",
-                    "sessions_spawn",
-                    "session_setThinking",
-                    "session_setVerbose",
-                    "session_setReasoning",
-                    "session_setLabel",
+                    "sessions.delete",
+                    "sessions.send",
+                    "sessions.kill",
+                    "sessions.spawn",
+                    "sessions.setThinking",
+                    "sessions.setVerbose",
+                    "sessions.setReasoning",
+                    "sessions.setLabel",
+                    "sessions.list",
                     "agents.list",
                     "models.list",
                     "config.get",
@@ -793,7 +803,71 @@ async fn handle_request_frame(
                 session_key,
             );
         }
-        "session_delete" => {
+        "sessions.list" => {
+            if !identity.allows(AuthScope::Read) {
+                let _ = send_error_response(sender, &id, "FORBIDDEN", "forbidden").await;
+                return Ok(());
+            }
+
+            let params = match serde_json::from_value::<SessionsListParams>(params) {
+                Ok(v) => v,
+                Err(err) => {
+                    let _ = send_error_response(
+                        sender,
+                        &id,
+                        "INVALID_REQUEST",
+                        &format!("invalid sessions.list params: {err}"),
+                    )
+                    .await;
+                    return Ok(());
+                }
+            };
+
+            let chats = match call_blocking(state.app_state.db.clone(), |db| {
+                db.get_recent_chats(400)
+            })
+            .await
+            {
+                Ok(chats) => chats,
+                Err(err) => {
+                    let _ =
+                        send_error_response(sender, &id, "INTERNAL_SERVER_ERROR", &err.to_string())
+                            .await;
+                    return Ok(());
+                }
+            };
+
+            let sessions = chats
+                .into_iter()
+                .map(|c| map_chat_to_session(&state.app_state.channel_registry, c))
+                .filter(|s| {
+                    if let Some(ref agent_id) = params.agent_id {
+                        if !s.session_key.starts_with(agent_id) {
+                            return false;
+                        }
+                    }
+                    if let Some(ref search_term) = params.search {
+                        if !search_term.is_empty() && !s.session_key.contains(search_term) {
+                            return false;
+                        }
+                    }
+                    true
+                })
+                .collect::<Vec<_>>();
+
+            let res = ResponseFrame {
+                kind: "res",
+                id: &id,
+                ok: true,
+                payload: Some(json!({
+                    "ok": true,
+                    "sessions": sessions,
+                })),
+                error: None,
+            };
+            let _ = send_json(sender, &res).await;
+        }
+        "sessions.delete" => {
             if !identity.allows(AuthScope::Write) {
                 let _ = send_error_response(sender, &id, "FORBIDDEN", "forbidden").await;
                 return Ok(());
@@ -839,7 +913,7 @@ async fn handle_request_frame(
             };
             let _ = send_json(sender, &res).await;
         }
-        "sessions_send" => {
+        "sessions.send" => {
             if !identity.allows(AuthScope::Write) {
                 let _ = send_error_response(sender, &id, "FORBIDDEN", "forbidden").await;
                 return Ok(());
@@ -935,7 +1009,7 @@ async fn handle_request_frame(
                 session_key,
             );
         }
-        "sessions_kill" => {
+        "sessions.kill" => {
             if !identity.allows(AuthScope::Write) {
                 let _ = send_error_response(sender, &id, "FORBIDDEN", "forbidden").await;
                 return Ok(());
@@ -985,7 +1059,7 @@ async fn handle_request_frame(
             };
             let _ = send_json(sender, &res).await;
         }
-        "sessions_spawn" => {
+        "sessions.spawn" => {
             if !identity.allows(AuthScope::Write) {
                 let _ = send_error_response(sender, &id, "FORBIDDEN", "forbidden").await;
                 return Ok(());
@@ -1072,10 +1146,10 @@ async fn handle_request_frame(
             };
             let _ = send_json(sender, &res).await;
         }
-        "session_setThinking"
-        | "session_setVerbose"
-        | "session_setReasoning"
-        | "session_setLabel" => {
+        "sessions.setThinking"
+        | "sessions.setVerbose"
+        | "sessions.setReasoning"
+        | "sessions.setLabel" => {
             if !identity.allows(AuthScope::Write) {
                 let _ = send_error_response(sender, &id, "FORBIDDEN", "forbidden").await;
                 return Ok(());


### PR DESCRIPTION
fix #295

- Rename all session-related WebSocket methods to standard `sessions.*` format (e.g., `sessions.send`, `sessions.delete`) for consistency and OpenClaw API compatibility.
- Update `sessions.list` to accept dynamic `agentId` and `search` filters via `SessionsListParams` instead of using a hardcoded filter.
- Add comprehensive unit tests in `src/web.rs` for `sessions.list` to verify filtering by agent ID, search string, and empty fallback logic.