### PR TITLE
feat(weixin): enable markdown in outbound messages

### DIFF
--- a/src/channels/weixin.rs
+++ b/src/channels/weixin.rs
@@ -1339,7 +1339,7 @@ async fn send_text_message_native(
             "item_list": [
                 {
                     "type": MSG_ITEM_TEXT,
-                    "text_item": { "text": text }
+                    "text_item": { "text": text, "content_type": "markdown" }
                 }
             ],
             "context_token": context_token,


### PR DESCRIPTION
## Summary
- Set `content_type: "markdown"` in outbound `text_item` so WeChat renders markdown formatting (bold, code blocks, lists, headings, etc.) natively
- Voice message support already works via `voice_item.text` — WeChat sends the transcript text directly, no additional transcription needed

## Notes
- Single-line change in `send_text_message_native`
- All existing weixin tests pass

## Test plan
- [ ] Send a message with markdown formatting (bold, code, lists) to a WeChat user and verify it renders correctly
- [ ] Verify plain text messages still display normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)