### PR TITLE
fix(nix): derive web npm deps from lockfile via importNpmLock

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,10 @@
           version = "0.1.0";
           src = ./web;
           npmBuildScript = "build";
-          npmDepsHash = "sha256-b4jpN4AD57bzvFAJueC4zuO0oTrDq/22TTfY9hvucNU=";
+          npmDeps = pkgs.importNpmLock {
+            npmRoot = ./web;
+          };
+          npmConfigHook = pkgs.importNpmLock.npmConfigHook;
 
           installPhase = ''
             runHook preInstall


### PR DESCRIPTION
## Summary
- Replace the hand-maintained `npmDepsHash` in `flake.nix` with `pkgs.importNpmLock`, which derives the fetch spec directly from `web/package-lock.json`.
- Future web dependency bumps (e.g. dependabot PRs like #326) will no longer fail the Nix build with `hash mismatch in fixed-output derivation '...-microclaw-web-assets-...-npm-deps.drv'`.

## Motivation
PR #326 (web dependency bump) is currently red on Nix Build (flake) because `flake.nix` still pins `npmDepsHash = "sha256-b4jp...";`, which no longer matches the new lockfile. Every future web bump would hit the same wall and require a manual hash update. `importNpmLock` eliminates that maintenance burden.

## Test plan
- [ ] Nix Build (flake) passes on this PR
- [ ] After merge, rebasing #326 onto main turns its Nix Build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)