### PR TITLE
fix(install): rename $pid param in install.ps1 to avoid PowerShell read-only var

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -84,11 +84,11 @@ function Ensure-UserPathContains([string]$dir) {
   return $true
 }
 
-function Wait-ForProcessExit([int]$pid) {
-  if ($pid -le 0) { return }
+function Wait-ForProcessExit([int]$ProcessId) {
+  if ($ProcessId -le 0) { return }
 
   try {
-    $process = Get-Process -Id $pid -ErrorAction SilentlyContinue
+    $process = Get-Process -Id $ProcessId -ErrorAction SilentlyContinue
     if ($null -ne $process) {
       $process.WaitForExit()
     }
@@ -132,7 +132,7 @@ try {
   $targetPath = Join-Path $InstallDir $BinName
   $stagedTargetPath = Join-Path $InstallDir ".$BinName.tmp.$PID"
 
-  Wait-ForProcessExit -pid $WaitForPid
+  Wait-ForProcessExit -ProcessId $WaitForPid
 
   Copy-Item -Path $bin.FullName -Destination $stagedTargetPath -Force
   if (Test-Path $targetPath) {


### PR DESCRIPTION
## Summary
- Fixes #343: native Windows install command `iwr https://microclaw.ai/install.ps1 -UseBasicParsing | iex` fails with `Invoke-Expression: Cannot overwrite variable pid because it is read-only or constant.`
- `$pid` is a PowerShell automatic, read-only variable (current session's PID). The `Wait-ForProcessExit([int]$pid)` parameter shadowed it, which PowerShell rejects when the script is dot-sourced via `iex`.
- Renamed the parameter (and its named-arg call site) to `$ProcessId`. The user-facing `-WaitForPid` script param and the `$PID` automatic variable used to build the staged temp filename are unchanged.

Note: identical copies live in the separate `website/` repo (`static/install.ps1`, `build/install.ps1`); those should be re-synced from this file.

## Test plan
- [ ] On Windows, run `iwr https://microclaw.ai/install.ps1 -UseBasicParsing | iex` and confirm no read-only-variable error.
- [ ] Run with `-WaitForPid <pid>` (the upgrade path invoked from `src/main.rs:161`) and confirm `Wait-ForProcessExit` still waits correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)