### PR TITLE
fix: UTF-8 safe string slicing in memory_backend.rs and web.rs

### DIFF
--- a/src/memory_backend.rs
+++ b/src/memory_backend.rs
@@ -356,7 +356,14 @@ impl MemoryBackend {
                     "source": source,
                     "confidence": confidence,
                     "content_len": content.len(),
-                    "content_preview": &content[..content.len().min(100)],
+                    "content_preview": {
+                        let max_bytes = content.len().min(100);
+                        let safe_end = content.char_indices()
+                            .skip_while(|(idx, _)| *idx < max_bytes)
+                            .next()
+                            .map_or(content.len(), |(idx, _)| idx);
+                        &content[..safe_end]
+                    },
                     "ts": chrono::Utc::now().to_rfc3339(),
                 }),
             );

--- a/src/memory_backend.rs
+++ b/src/memory_backend.rs
@@ -8,6 +8,7 @@ use tracing::{info, warn};
 
 use crate::mcp::{McpManager, McpServer, McpToolInfo};
 use microclaw_core::error::MicroClawError;
+use microclaw_core::text::floor_char_boundary;
 use microclaw_storage::db::{call_blocking, Database, Memory};
 
 #[derive(Clone)]
@@ -356,14 +357,7 @@ impl MemoryBackend {
                     "source": source,
                     "confidence": confidence,
                     "content_len": content.len(),
-                    "content_preview": {
-                        let max_bytes = content.len().min(100);
-                        let safe_end = content.char_indices()
-                            .skip_while(|(idx, _)| *idx < max_bytes)
-                            .next()
-                            .map_or(content.len(), |(idx, _)| idx);
-                        &content[..safe_end]
-                    },
+                    "content_preview": &content[..floor_char_boundary(content, 100)],
                     "ts": chrono::Utc::now().to_rfc3339(),
                 }),
             );

--- a/src/web.rs
+++ b/src/web.rs
@@ -2384,11 +2384,7 @@ mod tests {
     async fn seed_test_api_key_with_scopes(state: &WebState, secret: &str, scopes: &[String]) {
         let secret_owned = secret.to_string();
         let key_hash = sha256_hex(&secret_owned);
-        let max_bytes = secret_owned.len().min(6);
-        let safe_end = secret_owned.char_indices()
-            .skip_while(|(idx, _)| *idx < max_bytes)
-            .next()
-            .map_or(secret_owned.len(), |(idx, _)| idx);
+        let safe_end = microclaw_core::text::floor_char_boundary(&secret_owned, 6);
         let prefix = secret_owned[..safe_end].to_string();
         let scopes = scopes.to_vec();
         call_blocking(state.app_state.db.clone(), move |db| {

--- a/src/web.rs
+++ b/src/web.rs
@@ -2384,7 +2384,12 @@ mod tests {
     async fn seed_test_api_key_with_scopes(state: &WebState, secret: &str, scopes: &[String]) {
         let secret_owned = secret.to_string();
         let key_hash = sha256_hex(&secret_owned);
-        let prefix = secret_owned[..secret_owned.len().min(6)].to_string();
+        let max_bytes = secret_owned.len().min(6);
+        let safe_end = secret_owned.char_indices()
+            .skip_while(|(idx, _)| *idx < max_bytes)
+            .next()
+            .map_or(secret_owned.len(), |(idx, _)| idx);
+        let prefix = secret_owned[..safe_end].to_string();
         let scopes = scopes.to_vec();
         call_blocking(state.app_state.db.clone(), move |db| {
             db.upsert_auth_password_hash(&make_password_hash("passw0rd!"))?;


### PR DESCRIPTION
## Problem

MicroClaw panics when memory entries contain multi-byte UTF-8 characters (e.g. CJK):
```
byte index 100 is not a char boundary; it is inside '息' (bytes 98..101)
```

This happens at `memory_backend.rs:359` where `&content[..content.len().min(100)]` uses byte-based slicing.

## Fix

Replace byte-index slicing with `char_indices()` to find the nearest character boundary:

```rust
// Before (buggy):
&content[..content.len().min(100)]

// After (safe):
let max_bytes = content.len().min(100);
let safe_end = content.char_indices()
    .skip_while(|(idx, _)| *idx < max_bytes)
    .next()
    .map_or(content.len(), |(idx, _)| idx);
&content[..safe_end]
```

## Files Changed

- `src/memory_backend.rs` — content_preview truncation in `insert_memory_with_metadata`
- `src/web.rs` — API key prefix extraction (same pattern, lower risk)

## Testing

This is a drop-in replacement that produces identical results for ASCII-only strings and correct behavior for multi-byte UTF-8 strings. No API changes.

Fixes #380