### PR TITLE
Humanlike follow-ups: progress-reports toggle, relationship familiarity, task ETA

### DIFF
--- a/crates/microclaw-storage/src/db.rs
+++ b/crates/microclaw-storage/src/db.rs
@@ -3616,6 +3616,18 @@ impl Database {
         Ok(memories)
     }
 
+    /// Total number of stored messages in a chat (both sides). Used as a cheap
+    /// proxy for how well the bot "knows" this person.
+    pub fn count_messages_for_chat(&self, chat_id: i64) -> Result<i64, MicroClawError> {
+        let conn = self.lock_conn();
+        conn.query_row(
+            "SELECT COUNT(*) FROM messages WHERE chat_id = ?1",
+            params![chat_id],
+            |row| row.get(0),
+        )
+        .map_err(Into::into)
+    }
+
     pub fn get_active_chat_ids_since(&self, since: &str) -> Result<Vec<i64>, MicroClawError> {
         let conn = self.lock_conn();
         let mut stmt = conn.prepare(
@@ -4861,6 +4873,24 @@ impl Database {
             })
         })?;
         rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    }
+
+    /// Average wall-clock duration (seconds) of recently-completed sub-agent runs
+    /// in a chat, for rough ETA hints. `None` when there's no completed history.
+    pub fn avg_completed_subagent_duration_secs(
+        &self,
+        chat_id: i64,
+    ) -> Result<Option<i64>, MicroClawError> {
+        let conn = self.lock_conn();
+        let avg: Option<f64> = conn.query_row(
+            "SELECT AVG((julianday(finished_at) - julianday(started_at)) * 86400.0)
+             FROM subagent_runs
+             WHERE chat_id = ?1 AND status = 'completed'
+               AND started_at IS NOT NULL AND finished_at IS NOT NULL",
+            params![chat_id],
+            |row| row.get(0),
+        )?;
+        Ok(avg.map(|v| v.round() as i64).filter(|v| *v > 0))
     }
 
     /// All currently-active sub-agent runs across chats (accepted/queued/running),
@@ -7677,6 +7707,11 @@ mod tests {
         let idle = db.list_idle_chats("2030-01-01T00:00:00Z", 50).unwrap();
         assert!(idle.contains(&1));
         assert!(!idle.contains(&2));
+
+        // Familiarity proxy: message counts per chat.
+        assert_eq!(db.count_messages_for_chat(1).unwrap(), 1);
+        assert_eq!(db.count_messages_for_chat(2).unwrap(), 1);
+        assert_eq!(db.count_messages_for_chat(999).unwrap(), 0);
         cleanup(&dir);
     }
 

--- a/docs/IMPLEMENTED.md
+++ b/docs/IMPLEMENTED.md
@@ -90,3 +90,12 @@ subagents:
 - 新增/覆盖：`mood`（4）、`specialists`（3）、subagent label+progress+resolve（storage）、
   standup 格式化与 stalled（scheduler）、builtin skills 安装。
 - 已知失败：2 个 `hooks` 子进程测试在本沙箱环境失败，**在改动前的 baseline 同样失败**（环境性，与本分支无关）。
+
+## 跟进（后续 PR）
+
+| 项 | 状态 | 实现 / 位置 |
+|---|---|---|
+| 进度汇报可关 | ✅ | `subagents.progress_reports`（默认 true）。关闭后仍记录到时间线，仅不推送到聊天。`src/tools/report_progress.rs` |
+| 关系纵深（认识多久） | ✅ | `src/relationship.rs`：按消息量判定"很新/很熟"，注入 `# Relationship` 提示（中间不注入）。`db.count_messages_for_chat` |
+| 任务 ETA | ✅ | standup 用历史平均完成时长给"~还要 Xm"。`db.avg_completed_subagent_duration_secs` |
+| 专家间协作 / Inner Thoughts / 自发幽默 / 人格成长 | ⏳ | 仍属开放研究问题，见 `how-to-be-a-human.md` |

--- a/microclaw.config.example.yaml
+++ b/microclaw.config.example.yaml
@@ -261,6 +261,7 @@ web_session_idle_ttl_seconds: 300
 #   run_timeout_secs: 900          # per-run timeout
 #   announce_to_chat: true         # post a message when a run completes
 #   fan_in_summary: false          # when a batch of child tasks all finish, post one combined summary
+#   progress_reports: true         # whether sub-agents may post mid-run "📊 progress" updates to chat
 #   # How often a long-running sub-agent may post a "📊 progress" update (seconds).
 #   progress_min_interval_secs: 45
 #   # Proactive task standup: periodically post a one-line status for tasks that

--- a/src/agent_engine.rs
+++ b/src/agent_engine.rs
@@ -841,6 +841,19 @@ async fn process_with_agent_logic(
         );
     }
 
+    // Relationship familiarity: nudge tone by how much history we share with
+    // this person (welcoming for a brand-new chat, casual for a long-time one).
+    let message_count = call_blocking(state.db.clone(), move |db| {
+        db.count_messages_for_chat(chat_id)
+    })
+    .await
+    .unwrap_or(0);
+    if let Some(hint) = crate::relationship::familiarity_hint(message_count) {
+        system_prompt.push_str("\n# Relationship\n\n");
+        system_prompt.push_str(hint);
+        system_prompt.push('\n');
+    }
+
     debug!(
         chat_id,
         system_prompt_len = system_prompt.len(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -773,6 +773,8 @@ pub struct SubagentConfig {
     pub announce_to_chat: bool,
     #[serde(default)]
     pub fan_in_summary: bool,
+    #[serde(default = "default_true")]
+    pub progress_reports: bool,
     #[serde(default = "default_subagent_progress_min_interval_secs")]
     pub progress_min_interval_secs: u64,
     #[serde(default = "default_subagent_max_spawn_depth")]
@@ -801,6 +803,7 @@ impl Default for SubagentConfig {
             run_timeout_secs: default_subagent_run_timeout_secs(),
             announce_to_chat: default_subagent_announce(),
             fan_in_summary: false,
+            progress_reports: true,
             progress_min_interval_secs: default_subagent_progress_min_interval_secs(),
             max_spawn_depth: default_subagent_max_spawn_depth(),
             max_children_per_run: default_subagent_max_children_per_run(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub mod memory_service;
 pub mod mood;
 pub mod plugins;
 pub mod prompt_cache;
+pub mod relationship;
 pub(crate) mod run_control;
 pub mod runtime;
 pub mod scheduler;

--- a/src/relationship.rs
+++ b/src/relationship.rs
@@ -1,0 +1,54 @@
+//! Relationship familiarity: a light, prompt-level sense of how well the bot
+//! "knows" the person it's talking to, derived from how much history they share
+//! (the stored message count). People treat a stranger and an old friend
+//! differently; this nudges tone the same way.
+//!
+//! Conservative by design: only the extremes (brand-new vs. long-time) inject
+//! anything. The broad middle stays silent so we don't over-prompt.
+
+/// Threshold (messages) below which a chat is treated as brand-new.
+const NEW_MAX: i64 = 6;
+/// Threshold (messages) at/above which a chat is treated as long-running.
+const FAMILIAR_MIN: i64 = 200;
+
+/// One-line familiarity guidance for the system prompt, or `None` for the
+/// broad middle where no nudge is warranted.
+pub fn familiarity_hint(message_count: i64) -> Option<&'static str> {
+    if message_count < NEW_MAX {
+        Some(
+            "This looks like one of your first conversations with this person. Be welcoming and a \
+touch more explicit — you don't share much history yet, so don't assume prior context.",
+        )
+    } else if message_count >= FAMILIAR_MIN {
+        Some(
+            "You and this person go back a long way. You can be relaxed and familiar, and lean on \
+the history and context you already share.",
+        )
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_chats_get_a_welcoming_nudge() {
+        assert!(familiarity_hint(0).unwrap().contains("first conversations"));
+        assert!(familiarity_hint(5).is_some());
+    }
+
+    #[test]
+    fn the_middle_stays_silent() {
+        assert!(familiarity_hint(6).is_none());
+        assert!(familiarity_hint(50).is_none());
+        assert!(familiarity_hint(199).is_none());
+    }
+
+    #[test]
+    fn long_running_chats_get_a_familiar_nudge() {
+        assert!(familiarity_hint(200).unwrap().contains("go back a long way"));
+        assert!(familiarity_hint(5000).is_some());
+    }
+}

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -433,7 +433,13 @@ async fn run_task_standup(
             .first()
             .map(|r| r.caller_channel.clone())
             .unwrap_or_default();
-        let message = format_standup(&chat_runs, now, interval_secs);
+        let avg_duration_secs = call_blocking(state.db.clone(), move |db| {
+            db.avg_completed_subagent_duration_secs(chat_id)
+        })
+        .await
+        .ok()
+        .flatten();
+        let message = format_standup(&chat_runs, now, interval_secs, avg_duration_secs);
         let bot_username = state.config.bot_username_for_channel(&channel);
         match deliver_and_store_bot_message(
             &state.channel_registry,
@@ -579,6 +585,7 @@ fn format_standup(
     runs: &[microclaw_storage::db::SubagentRunRecord],
     now: chrono::DateTime<Utc>,
     interval_secs: u64,
+    avg_duration_secs: Option<i64>,
 ) -> String {
     let n = runs.len();
     let header = format!(
@@ -615,7 +622,15 @@ fn format_standup(
         let stale_progress = progress_age.map(|a| a >= interval).unwrap_or(true);
         let stalled = age_secs.map(|a| a >= 2 * interval).unwrap_or(false) && stale_progress;
         let flag = if stalled { " ⚠️ no recent progress" } else { "" };
-        lines.push(format!("• {name} ({age}){progress}{flag}"));
+        // Rough ETA from the chat's historical average run duration, shown only
+        // while the task is still under that average (and not flagged stalled).
+        let eta = match (avg_duration_secs, age_secs) {
+            (Some(avg), Some(age)) if !stalled && age < avg => {
+                format!(", ~{} left", format_duration_secs(avg - age))
+            }
+            _ => String::new(),
+        };
+        lines.push(format!("• {name} ({age}{eta}){progress}{flag}"));
     }
     lines.join("\n")
 }
@@ -1330,7 +1345,7 @@ mod tests {
             progress_text: Some("checked 3/5 vendors".into()),
             last_progress_at: None,
         };
-        let out = format_standup(std::slice::from_ref(&run), now, 1800);
+        let out = format_standup(std::slice::from_ref(&run), now, 1800, None);
         assert!(out.contains("1 task running"));
         assert!(out.contains("competitor research"));
         assert!(out.contains("checked 3/5 vendors"));
@@ -1370,8 +1385,44 @@ mod tests {
             progress_text: None,
             last_progress_at: None,
         };
-        let out = format_standup(std::slice::from_ref(&run), now, 1800);
+        let out = format_standup(std::slice::from_ref(&run), now, 1800, Some(600));
         assert!(out.contains("no recent progress"), "expected stalled flag: {out}");
+    }
+
+    #[test]
+    fn test_format_standup_shows_eta_when_under_average() {
+        use microclaw_storage::db::SubagentRunRecord;
+        let now = Utc::now();
+        // Running 2 min, average completed run is 10 min → ~8m left, no stall flag.
+        let run = SubagentRunRecord {
+            run_id: "subrun-eta".into(),
+            parent_run_id: None,
+            depth: 1,
+            chat_id: 7,
+            caller_channel: "telegram".into(),
+            task: "build report".into(),
+            context: String::new(),
+            status: "running".into(),
+            created_at: (now - chrono::Duration::seconds(120)).to_rfc3339(),
+            started_at: None,
+            finished_at: None,
+            cancel_requested: false,
+            error_text: None,
+            result_text: None,
+            input_tokens: 0,
+            output_tokens: 0,
+            total_tokens: 0,
+            provider: "anthropic".into(),
+            model: "claude-test".into(),
+            token_budget: 0,
+            artifact_json: None,
+            label: Some("report".into()),
+            progress_text: None,
+            last_progress_at: None,
+        };
+        let out = format_standup(std::slice::from_ref(&run), now, 1800, Some(600));
+        assert!(out.contains("left"), "expected ETA: {out}");
+        assert!(!out.contains("no recent progress"));
     }
 
     #[test]

--- a/src/tools/report_progress.rs
+++ b/src/tools/report_progress.rs
@@ -102,6 +102,14 @@ impl Tool for ReportProgressTool {
             Err(e) => return ToolResult::error(format!("Failed recording progress: {e}")),
         };
 
+        // Progress is always recorded on the run timeline (so subagents_list /
+        // standup can show it); delivery to chat is what the toggle controls.
+        if !self.config.subagents.progress_reports {
+            return ToolResult::success(
+                json!({"status": "recorded", "delivered": false, "reason": "disabled"}).to_string(),
+            );
+        }
+
         let min_interval = self.config.subagents.progress_min_interval_secs as i64;
         let throttled = prev_progress_at
             .as_deref()


### PR DESCRIPTION
Follow-ups to #391, picking the tractable items from the "How to Be a Human" backlog. Each is small, independent, and clean.

## What's included

### 1. `subagents.progress_reports` toggle (default `true`)
Makes the one proactive behavior that was on-by-default fully controllable. When off, sub-agents still **record** progress to the run timeline (so `subagents_list` / standup keep showing it) — only **chat delivery** of the `📊` message is suppressed. This closes the gap flagged during #391 review (mid-run progress had no off-switch).

### 2. Relationship familiarity (`src/relationship.rs`)
People treat a stranger and an old friend differently. Derived from how much history we share (`db.count_messages_for_chat`), the system prompt gets a one-line nudge:
- brand-new chat (< 6 messages) → welcoming, don't assume prior context;
- long-running chat (≥ 200 messages) → relaxed and familiar;
- the broad middle → nothing (conservative, no over-prompting).

### 3. Task ETA in the standup
The proactive standup now shows a rough `~Xm left` from the chat's historical average completed-run duration (`db.avg_completed_subagent_duration_secs`), shown only while a task is under that average and not already flagged stalled.

## Behavior / compatibility
- All additive: new config field defaults preserve current behavior; new DB methods are read-only queries (no migration).
- Relationship nudge is prompt-only and conservative; ETA only appears in the opt-in standup.

## Lint / tests
- `cargo clippy --all-targets -- -D warnings` — **clean** (verified locally before pushing).
- `cargo build` clean; generated-docs `--check` passes; example config documents the new knob.
- New tests: relationship tiers, standup ETA line, message-count proxy.

## Still open (research-hard, deliberately not in scope)
Specialist-to-specialist collaboration, continuous "inner thoughts" proactivity, spontaneous humor, and an evolving personality remain open — documented in `docs/how-to-be-a-human.md`.

https://claude.ai/code/session_01BoPjHdAYeCwh75QvvwgYzZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01BoPjHdAYeCwh75QvvwgYzZ)_