### PR TITLE
build(deps): pin sqlite-vec to stable 0.1.8 instead of prerelease

### DIFF
--- a/crates/microclaw-storage/Cargo.toml
+++ b/crates/microclaw-storage/Cargo.toml
@@ -15,4 +15,4 @@ rusqlite = { version = "0.37", features = ["bundled"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 uuid = { version = "1", features = ["v4"] }
-sqlite-vec = { version = "0.1.8-alpha.1", optional = true }
+sqlite-vec = { version = "0.1.8", optional = true }


### PR DESCRIPTION
## Problem

`crates/microclaw-storage/Cargo.toml` declared the dependency as:

```toml
sqlite-vec = { version = "0.1.8-alpha.1", optional = true }
```

The `-alpha.1` prerelease tag makes Cargo (and therefore Dependabot) treat the dependency as opted into prereleases, so Dependabot keeps proposing newer alphas such as `0.1.10-alpha.4`.

`Cargo.lock` already resolved to the **stable** `0.1.8`, so the prerelease requirement was the only thing driving the alpha upgrade suggestions.

## Fix

Tighten the requirement to the stable release:

```toml
sqlite-vec = { version = "0.1.8", optional = true }
```

- No `Cargo.lock` change needed — it was already at `0.1.8`.
- Dependabot will now only suggest stable upgrades (`0.1.9`, `0.1.10`, …) and stop guiding alpha bumps.

https://claude.ai/code/session_01GKM6hxBkkxVxsHcHxaj79M

---
_Generated by [Claude Code](https://claude.ai/code/session_01GKM6hxBkkxVxsHcHxaj79M)_