### PR TITLE
fix(weixin): split long outbound messages to avoid truncation

### DIFF
--- a/src/channels/weixin.rs
+++ b/src/channels/weixin.rs
@@ -28,9 +28,14 @@ use crate::runtime::AppState;
 use crate::setup_def::{ChannelFieldDef, DynamicChannelDef};
 use microclaw_channels::channel::ConversationKind;
 use microclaw_channels::channel_adapter::ChannelAdapter;
+use microclaw_core::text::split_text;
 use microclaw_storage::db::{call_blocking, StoredMessage};
 
 const CHANNEL_KEY: &str = "weixin";
+/// Max bytes per outbound Weixin text item. The ilink `sendmessage` API
+/// silently truncates anything longer, so long replies are split into
+/// multiple messages at newline boundaries (see `split_text`).
+const WEIXIN_TEXT_MAX_LEN: usize = 2048;
 const DEFAULT_BASE_URL: &str = "https://ilinkai.weixin.qq.com";
 const DEFAULT_CDN_BASE_URL: &str = "https://novac2c.cdn.weixin.qq.com/c2c";
 const DEFAULT_WEBHOOK_PATH: &str = "/weixin/messages";
@@ -1945,15 +1950,22 @@ impl ChannelAdapter for WeixinAdapter {
             )
         })?;
         let account = self.load_native_account()?;
-        send_text_message_native(
-            &self.http_client,
-            &account,
-            external_chat_id,
-            text,
-            &context_token,
-        )
-        .await
-        .map(|_| ())
+        // The ilink sendmessage API truncates over-long text items, so split
+        // long replies into multiple messages like the other channel adapters.
+        for chunk in split_text(text, WEIXIN_TEXT_MAX_LEN) {
+            if chunk.is_empty() {
+                continue;
+            }
+            send_text_message_native(
+                &self.http_client,
+                &account,
+                external_chat_id,
+                &chunk,
+                &context_token,
+            )
+            .await?;
+        }
+        Ok(())
     }
 
     async fn send_attachment(


### PR DESCRIPTION
## Problem

WeChat bot replies were getting cut off mid-content (see reported screenshots: a usage guide truncated at `vm4a create`, after which the model would apologize that "the doc is too long to send at once"). The apology was a red herring — the model produced the full reply, but the **platform silently truncated it**.

## Root cause

`src/channels/weixin.rs`'s outbound `send_text` passed the entire response string to the ilink `sendmessage` API in a single call, with no chunking. The ilink API silently truncates a text item past its per-message limit, so anything beyond that was dropped.

weixin was the **only** outbound delivery adapter missing this guard — every other one already wraps `send_text` in `split_text(...)`:

| Adapter | Chunk limit |
|---|---|
| Discord | 2000 |
| Feishu / Slack | 4000 |
| Matrix | 3800 |
| WhatsApp | 3000 |
| iMessage | 1500 |
| email | 8000 |
| **weixin (before)** | **none** |

## Fix

`send_text` now splits long replies at newline boundaries via the shared `split_text` helper and sends each chunk as a separate message (awaited sequentially, preserving order). The limit is a conservative `WEIXIN_TEXT_MAX_LEN = 2048` bytes, aligned with WeChat's common text limit; since `split_text` counts bytes, each chunk stays ≤2048 chars worst case.

## Notes

Like the other adapters, splitting happens on raw newline boundaries, so a very long fenced code block could still be split across two messages — a pre-existing, cross-channel limitation. This PR keeps weixin consistent with the others rather than special-casing it.

## Testing

- `cargo build -p microclaw` — clean
- `cargo test -p microclaw --lib channels::weixin` — 11 passed

https://claude.ai/code/session_01DU7fq8LMQp9njifv5maKfM

---
_Generated by [Claude Code](https://claude.ai/code/session_01DU7fq8LMQp9njifv5maKfM)_