### PR TITLE
feat(config): route memory reflector through aux_models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,15 @@ The format is loosely based on Keep a Changelog. Dates use UTC.
 ### Added
 
 - Per-task auxiliary models: a new `aux_models` config section lets a (typically
-  cheaper) model handle ancillary work. The first wired slot, `aux_models.compaction`,
-  runs context/history summarization on the configured model instead of the main
-  conversation model. The auxiliary model reuses the main provider profile and
-  credentials — only the model name is swapped — and falls back to the main model when
-  unset, so default behavior is unchanged. First step toward the v0.3.0
-  "Self-Improving Runtime" plan (`docs/roadmap/v0.3.0-self-improving-runtime.md`).
+  cheaper) model handle ancillary work. Wired slots:
+  - `aux_models.compaction` — context/history summarization.
+  - `aux_models.reflector` — the background memory reflector (fact/triple extraction),
+    which runs periodically per active chat.
+
+  Each auxiliary model reuses the main provider profile and credentials — only the
+  model name is swapped — and falls back to the main model when unset, so default
+  behavior is unchanged. First steps toward the v0.3.0 "Self-Improving Runtime" plan
+  (`docs/roadmap/v0.3.0-self-improving-runtime.md`).
 
 ## 0.2.0 - 2026-06-01
 

--- a/microclaw.config.example.yaml
+++ b/microclaw.config.example.yaml
@@ -29,6 +29,7 @@ max_tool_iterations: 100
 # the model name is swapped — and falls back to the main model when unset.
 # aux_models:
 #   compaction: claude-haiku-4-5   # cheaper model for context/history summarization
+#   reflector: claude-haiku-4-5    # cheaper model for the background memory reflector
 # Inject pending messages into the active agent loop between iterations (mid-turn injection)
 enable_mid_turn_injection: true
 # On non-web channels (Telegram, Discord, Slack, Feishu, Matrix, WeChat),

--- a/src/config.rs
+++ b/src/config.rs
@@ -784,6 +784,11 @@ pub struct AuxModels {
     /// main model when unset or empty.
     #[serde(default)]
     pub compaction: Option<String>,
+    /// Model used by the background memory reflector (fact/triple extraction). This
+    /// runs periodically per active chat, so a cheaper model here is pure savings.
+    /// Falls back to the main model when unset or empty.
+    #[serde(default)]
+    pub reflector: Option<String>,
 }
 
 impl AuxModels {
@@ -793,6 +798,15 @@ impl AuxModels {
         match self.compaction.as_deref() {
             Some(m) if !m.trim().is_empty() => m,
             _ => main,
+        }
+    }
+
+    /// Optional model override for the memory reflector. Returns `None` (use the
+    /// provider's default model) when unset or empty, preserving prior behavior.
+    pub fn reflector_model(&self) -> Option<&str> {
+        match self.reflector.as_deref() {
+            Some(m) if !m.trim().is_empty() => Some(m),
+            _ => None,
         }
     }
 }
@@ -2773,6 +2787,7 @@ mod tests {
     fn aux_models_compaction_override_is_used() {
         let aux = AuxModels {
             compaction: Some("cheap-model".to_string()),
+            ..Default::default()
         };
         assert_eq!(aux.compaction_model("main-model"), "cheap-model");
     }
@@ -2781,18 +2796,38 @@ mod tests {
     fn aux_models_blank_override_falls_back() {
         let aux = AuxModels {
             compaction: Some("   ".to_string()),
+            ..Default::default()
         };
         assert_eq!(aux.compaction_model("main-model"), "main-model");
     }
 
     #[test]
     fn aux_models_parse_from_yaml() {
-        let yaml = "telegram_bot_token: tok\nbot_username: bot\napi_key: key\naux_models:\n  compaction: claude-haiku-4-5\n";
+        let yaml = "telegram_bot_token: tok\nbot_username: bot\napi_key: key\naux_models:\n  compaction: claude-haiku-4-5\n  reflector: claude-haiku-4-5\n";
         let config: Config = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(
             config.aux_models.compaction.as_deref(),
             Some("claude-haiku-4-5")
         );
+        assert_eq!(
+            config.aux_models.reflector_model(),
+            Some("claude-haiku-4-5")
+        );
+    }
+
+    #[test]
+    fn aux_models_reflector_default_is_none() {
+        let aux = AuxModels::default();
+        assert_eq!(aux.reflector_model(), None);
+    }
+
+    #[test]
+    fn aux_models_reflector_blank_is_none() {
+        let aux = AuxModels {
+            reflector: Some("  ".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(aux.reflector_model(), None);
     }
 
     #[test]

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1141,9 +1141,17 @@ async fn reflect_for_chat(state: &Arc<AppState>, chat_id: i64) {
             "Extract memories from this conversation (chat_id={chat_id}):{existing_hint}{user_model_block}\n\nConversation:\n{conversation}"
         )),
     };
+    // The reflector is background, quality-tolerant work, so allow a (typically
+    // cheaper) auxiliary model to handle it on the same provider. When no aux
+    // model is configured, this passes `None` and behaves exactly as before.
     let response = match state
         .llm
-        .send_message(REFLECTOR_SYSTEM_PROMPT, vec![user_msg], None)
+        .send_message_with_model(
+            REFLECTOR_SYSTEM_PROMPT,
+            vec![user_msg],
+            None,
+            state.config.aux_models.reflector_model(),
+        )
         .await
     {
         Ok(r) => r,


### PR DESCRIPTION
Closes #405. Follow-up to #403.

## What

Adds an `aux_models.reflector` slot and wires the background memory reflector (`reflect_for_chat()` in `src/scheduler.rs`) through it. The reflector extracts durable facts/triples from conversations on a periodic, per-active-chat schedule, so running it on a cheaper model is close to pure savings — and it advances the v0.3.0 "self-curating memory" track.

```yaml
aux_models:
  reflector: claude-haiku-4-5   # cheaper model for the background memory reflector
```

Reuses the main provider/credentials (only the model name swaps). When unset, the reflector passes `None` to `send_message_with_model`, so **default behavior is unchanged**.

## Changes

- `src/config.rs`: `AuxModels.reflector` field + `reflector_model()` (returns `None` when unset/blank, preserving prior behavior).
- `src/scheduler.rs`: `reflect_for_chat()` calls `send_message_with_model(REFLECTOR_SYSTEM_PROMPT, …, None, aux_models.reflector_model())` instead of `send_message(…)`.
- `microclaw.config.example.yaml`, `CHANGELOG.md`: documented.
- Tests: reflector slot resolution (default/blank → `None`, set → `Some`) and YAML parse; updated the existing `AuxModels` struct-literal tests to `..Default::default()`.

## Verification

- `cargo test --lib aux_models` — 7 passed (compiles, so the `scheduler.rs` call-site change is type-checked).

## Compatibility / rollback

No schema migration. No default behavior change (slot unset ⇒ provider default model). Clean revert.

---
https://claude.ai/code/session_0139tsJZ9v1Um6fNrP7K72MZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0139tsJZ9v1Um6fNrP7K72MZ)_