### PR TITLE
feat: sleep-time memory consolidation (deterministic, off by default)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ The format is loosely based on Keep a Changelog. Dates use UTC.
   model name is swapped — and falls back to the main model when unset, so default
   behavior is unchanged. First steps toward the v0.3.0 "Self-Improving Runtime" plan
   (`docs/roadmap/v0.3.0-self-improving-runtime.md`).
+- Sleep-time memory consolidation (`sleep_time`, off by default) — when a chat has been
+  idle for a while, a background loop runs a deterministic (no-LLM) pass that archives
+  near-duplicate same-category memories, so the store stops accumulating redundancy
+  between reflector runs. PROFILE (identity) memories are never touched, archiving is
+  reversible, and the pass is throttled per chat (`min_interval_hours`) and capped
+  (`max_archived_per_pass`). First slice of the v0.3.0 sleep-time consolidation (Pillar 1c).
 - `microclaw eval` subcommand — a deterministic trajectory-evaluation gate for recorded
   agent sessions, with no LLM call. It replays a session fixture (a JSON array of
   messages, or an object with a `messages` array) and checks trajectory health:

--- a/microclaw.config.example.yaml
+++ b/microclaw.config.example.yaml
@@ -291,6 +291,17 @@ web_session_idle_ttl_seconds: 300
 #   idle_hours: 24                 # only consider a chat idle after this many hours of silence
 #   min_interval_hours: 24         # at most one check-in per chat per this many hours
 
+# "Sleep-time" memory consolidation: when a chat is idle, run a deterministic
+# (no-LLM) background pass that archives near-duplicate memories so the store stops
+# accumulating redundancy between reflector runs. PROFILE memories are never touched,
+# archiving is reversible, and the pass is capped + throttled. OFF by default.
+# sleep_time:
+#   enabled: false
+#   idle_hours: 6                  # only consolidate a chat after this many hours of silence
+#   min_interval_hours: 24         # at most one consolidation pass per chat per this many hours
+#   similarity_threshold: 0.82     # Jaccard similarity at/above which same-category memories are duplicates
+#   max_archived_per_pass: 20      # safety cap on archives per chat per pass
+
 # "Inner thoughts" interjection: in an active group chat where the bot wasn't
 # addressed, occasionally chime in IF it has something genuinely worth saying.
 # OFF by default (it speaks unprompted in groups and uses an LLM call per check).

--- a/src/config.rs
+++ b/src/config.rs
@@ -890,6 +890,56 @@ impl Default for SubagentStandupConfig {
     }
 }
 
+fn default_sleep_time_idle_hours() -> u64 {
+    6
+}
+fn default_sleep_time_min_interval_hours() -> u64 {
+    24
+}
+fn default_sleep_time_similarity_threshold() -> f64 {
+    0.82
+}
+fn default_sleep_time_max_archived_per_pass() -> usize {
+    20
+}
+
+/// "Sleep-time" memory consolidation: when a chat has been idle for a while, run a
+/// background, deterministic (no-LLM) pass that archives near-duplicate memories so
+/// the store stops accumulating redundancy between reflector runs. PROFILE memories
+/// are never touched, archiving is reversible, and the pass is capped and throttled.
+/// OFF by default. First slice of the v0.3.0 "Self-Improving Runtime" sleep-time
+/// consolidation (Pillar 1c).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SleepTimeConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    /// Only consolidate a chat after this many hours with no messages.
+    #[serde(default = "default_sleep_time_idle_hours")]
+    pub idle_hours: u64,
+    /// At most one consolidation pass per chat per this many hours.
+    #[serde(default = "default_sleep_time_min_interval_hours")]
+    pub min_interval_hours: u64,
+    /// Jaccard similarity at/above which two same-category memories are treated as
+    /// duplicates (the lower-confidence one is archived). Clamped to [0.5, 1.0].
+    #[serde(default = "default_sleep_time_similarity_threshold")]
+    pub similarity_threshold: f64,
+    /// Safety cap on how many memories a single pass may archive per chat.
+    #[serde(default = "default_sleep_time_max_archived_per_pass")]
+    pub max_archived_per_pass: usize,
+}
+
+impl Default for SleepTimeConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            idle_hours: default_sleep_time_idle_hours(),
+            min_interval_hours: default_sleep_time_min_interval_hours(),
+            similarity_threshold: default_sleep_time_similarity_threshold(),
+            max_archived_per_pass: default_sleep_time_max_archived_per_pass(),
+        }
+    }
+}
+
 fn default_idle_checkin_idle_hours() -> u64 {
     24
 }
@@ -1139,6 +1189,8 @@ pub struct Config {
     pub subagents: SubagentConfig,
     #[serde(default)]
     pub idle_checkin: IdleCheckinConfig,
+    #[serde(default)]
+    pub sleep_time: SleepTimeConfig,
     #[serde(default)]
     pub interjection: InterjectionConfig,
     #[serde(default)]
@@ -1788,6 +1840,7 @@ impl Config {
             show_thinking: false,
             subagents: SubagentConfig::default(),
             idle_checkin: IdleCheckinConfig::default(),
+            sleep_time: SleepTimeConfig::default(),
             interjection: InterjectionConfig::default(),
             a2a: A2AConfig::default(),
             openai_compat_body_overrides: HashMap::new(),

--- a/src/memory_service.rs
+++ b/src/memory_service.rs
@@ -99,6 +99,48 @@ pub(crate) fn jaccard_similar(a: &str, b: &str, threshold: f64) -> bool {
     intersection as f64 / union as f64 >= threshold
 }
 
+/// A minimal view of a memory for sleep-time consolidation.
+#[derive(Debug, Clone)]
+pub(crate) struct ConsolidationItem {
+    pub id: i64,
+    pub content: String,
+    pub category: String,
+}
+
+/// Select near-duplicate memories to archive during a sleep-time consolidation pass.
+///
+/// `items` must be pre-sorted **best-first** (e.g. highest confidence / most recent
+/// first): the first member of each duplicate group is kept and later same-category
+/// near-duplicates are archived. PROFILE memories are always kept (they describe the
+/// user's identity). Returns the ids to archive, capped at `max`.
+pub(crate) fn select_duplicate_memories_to_archive(
+    items: &[ConsolidationItem],
+    threshold: f64,
+    max: usize,
+) -> Vec<i64> {
+    let threshold = threshold.clamp(0.5, 1.0);
+    let mut kept: Vec<&ConsolidationItem> = Vec::new();
+    let mut archive: Vec<i64> = Vec::new();
+    for it in items {
+        if it.category == "PROFILE" {
+            kept.push(it);
+            continue;
+        }
+        let is_dup = kept.iter().any(|k| {
+            k.category == it.category && jaccard_similar(&k.content, &it.content, threshold)
+        });
+        if is_dup {
+            archive.push(it.id);
+            if archive.len() >= max {
+                break;
+            }
+        } else {
+            kept.push(it);
+        }
+    }
+    archive
+}
+
 fn should_merge_duplicate(
     existing: &Memory,
     incoming_content: &str,
@@ -953,6 +995,71 @@ mod recency_tests {
         let stale = (now - chrono::Duration::days(365)).to_rfc3339();
         let m = mk("EVENT", &stale, 0.7);
         assert!((effective_memory_score(&m, now, 0.0) - 0.7).abs() < 1e-9);
+    }
+}
+
+#[cfg(test)]
+mod consolidation_tests {
+    use super::{select_duplicate_memories_to_archive, ConsolidationItem};
+
+    fn item(id: i64, content: &str, category: &str) -> ConsolidationItem {
+        ConsolidationItem {
+            id,
+            content: content.into(),
+            category: category.into(),
+        }
+    }
+
+    #[test]
+    fn archives_near_duplicate_keeping_first() {
+        let items = vec![
+            item(1, "user prefers concise replies and bullet points", "KNOWLEDGE"),
+            item(2, "user prefers concise replies and bullet points please", "KNOWLEDGE"),
+            item(3, "user lives in Berlin", "KNOWLEDGE"),
+        ];
+        let archived = select_duplicate_memories_to_archive(&items, 0.7, 20);
+        assert_eq!(archived, vec![2], "only the later near-duplicate is archived");
+    }
+
+    #[test]
+    fn never_archives_profile() {
+        let items = vec![
+            item(1, "name is Alex", "PROFILE"),
+            item(2, "name is Alex", "PROFILE"),
+        ];
+        let archived = select_duplicate_memories_to_archive(&items, 0.7, 20);
+        assert!(archived.is_empty(), "PROFILE memories are always kept");
+    }
+
+    #[test]
+    fn different_categories_are_not_duplicates() {
+        let items = vec![
+            item(1, "shipping the release today", "EVENT"),
+            item(2, "shipping the release today", "KNOWLEDGE"),
+        ];
+        let archived = select_duplicate_memories_to_archive(&items, 0.7, 20);
+        assert!(archived.is_empty());
+    }
+
+    #[test]
+    fn respects_max_cap() {
+        let items = vec![
+            item(1, "alpha beta gamma delta", "KNOWLEDGE"),
+            item(2, "alpha beta gamma delta", "KNOWLEDGE"),
+            item(3, "alpha beta gamma delta", "KNOWLEDGE"),
+        ];
+        let archived = select_duplicate_memories_to_archive(&items, 0.7, 1);
+        assert_eq!(archived.len(), 1, "cap limits archives per pass");
+    }
+
+    #[test]
+    fn distinct_memories_are_kept() {
+        let items = vec![
+            item(1, "user is a rust developer", "KNOWLEDGE"),
+            item(2, "user enjoys hiking on weekends", "KNOWLEDGE"),
+        ];
+        let archived = select_duplicate_memories_to_archive(&items, 0.82, 20);
+        assert!(archived.is_empty());
     }
 }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -520,6 +520,7 @@ pub async fn run(
     crate::scheduler::spawn_reflector(state.clone());
     crate::scheduler::spawn_task_standup(state.clone());
     crate::scheduler::spawn_idle_checkin(state.clone());
+    crate::scheduler::spawn_memory_consolidation(state.clone());
     crate::scheduler::spawn_interjection(state.clone());
     {
         let review_state = state.clone();

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -579,6 +579,122 @@ async fn run_idle_checkin(state: &Arc<AppState>, last_checkin: &mut HashMap<i64,
     }
 }
 
+/// "Sleep-time" memory consolidation loop: when a chat has been idle for a while,
+/// run a deterministic (no-LLM) pass that archives near-duplicate memories so the
+/// store stops accumulating redundancy between reflector runs. OFF by default.
+pub fn spawn_memory_consolidation(state: Arc<AppState>) {
+    if !state.config.sleep_time.enabled {
+        return;
+    }
+    tokio::spawn(async move {
+        info!(
+            "Sleep-time consolidation started (idle_hours={}, min_interval_hours={}, threshold={})",
+            state.config.sleep_time.idle_hours,
+            state.config.sleep_time.min_interval_hours,
+            state.config.sleep_time.similarity_threshold
+        );
+        let mut last_run: HashMap<i64, Instant> = HashMap::new();
+        let mut ticker = tokio::time::interval(Duration::from_secs(1800));
+        ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+        loop {
+            ticker.tick().await;
+            run_memory_consolidation(&state, &mut last_run).await;
+        }
+    });
+}
+
+async fn run_memory_consolidation(state: &Arc<AppState>, last_run: &mut HashMap<i64, Instant>) {
+    let cfg = &state.config.sleep_time;
+    let idle_hours = cfg.idle_hours.max(1) as i64;
+    let min_interval = Duration::from_secs(cfg.min_interval_hours.max(1).saturating_mul(3600));
+    let threshold = cfg.similarity_threshold;
+    let max_archived = cfg.max_archived_per_pass.max(1);
+    let cutoff = (Utc::now() - chrono::Duration::hours(idle_hours)).to_rfc3339();
+
+    let chats = match call_blocking(state.db.clone(), move |db| db.list_idle_chats(&cutoff, 100))
+        .await
+    {
+        Ok(v) => v,
+        Err(e) => {
+            warn!("sleep-time consolidation: failed to list idle chats: {e}");
+            return;
+        }
+    };
+
+    for chat_id in chats {
+        // Respect the per-chat min interval.
+        if let Some(t) = last_run.get(&chat_id) {
+            if t.elapsed() < min_interval {
+                continue;
+            }
+        }
+
+        let memories = match call_blocking(state.db.clone(), move |db| {
+            db.get_all_memories_for_chat(Some(chat_id))
+        })
+        .await
+        {
+            Ok(m) => m,
+            Err(e) => {
+                warn!("sleep-time consolidation: failed to load memories for chat {chat_id}: {e}");
+                continue;
+            }
+        };
+
+        let now = Utc::now().to_rfc3339();
+        // Active, non-expired memories, sorted best-first (confidence desc, recency desc)
+        // so the strongest member of each duplicate group is the one kept.
+        let mut active: Vec<_> = memories
+            .into_iter()
+            .filter(|m| !m.is_archived)
+            .filter(|m| m.expires_at.as_deref().map(|e| e > now.as_str()).unwrap_or(true))
+            .collect();
+        active.sort_by(|a, b| {
+            b.confidence
+                .partial_cmp(&a.confidence)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| b.last_seen_at.cmp(&a.last_seen_at))
+        });
+
+        let items: Vec<crate::memory_service::ConsolidationItem> = active
+            .iter()
+            .map(|m| crate::memory_service::ConsolidationItem {
+                id: m.id,
+                content: m.content.clone(),
+                category: m.category.clone(),
+            })
+            .collect();
+        let to_archive = crate::memory_service::select_duplicate_memories_to_archive(
+            &items,
+            threshold,
+            max_archived,
+        );
+
+        // Mark the chat as processed regardless, so we don't rescan every tick.
+        last_run.insert(chat_id, Instant::now());
+
+        if to_archive.is_empty() {
+            continue;
+        }
+
+        let mut archived = 0usize;
+        for id in &to_archive {
+            let id = *id;
+            match call_blocking(state.db.clone(), move |db| db.archive_memory(id)).await {
+                Ok(true) => archived += 1,
+                Ok(false) => {}
+                Err(e) => warn!("sleep-time consolidation: archive {id} failed: {e}"),
+            }
+        }
+        if archived > 0 {
+            info!(
+                "Sleep-time consolidation: archived {} duplicate memories in chat {}",
+                archived, chat_id
+            );
+        }
+    }
+}
+
 /// "Inner thoughts" interjection: in an active group chat where the bot wasn't
 /// addressed, occasionally evaluate whether it has something genuinely worth
 /// saying and, if so, chime in once. OFF by default — outward-facing and uses

--- a/tests/config_validation.rs
+++ b/tests/config_validation.rs
@@ -50,6 +50,7 @@ fn minimal_config() -> Config {
         show_thinking: false,
         subagents: microclaw::config::SubagentConfig::default(),
         idle_checkin: microclaw::config::IdleCheckinConfig::default(),
+        sleep_time: microclaw::config::SleepTimeConfig::default(),
         interjection: microclaw::config::InterjectionConfig::default(),
         a2a: microclaw::config::A2AConfig::default(),
         openai_compat_body_overrides: std::collections::HashMap::new(),


### PR DESCRIPTION
Closes #411.

## What

Adds a background "sleep-time" memory-consolidation loop (`sleep_time`, **off by default**). When a chat has been idle for a while, it runs a **deterministic, no-LLM** pass that archives near-duplicate same-category memories so the store stops accumulating redundancy between reflector runs. This is the first slice of v0.3.0 Pillar 1c — now safe to land behind the eval gate (#408/#410) and cheap aux models (#403/#406).

```yaml
sleep_time:
  enabled: false
  idle_hours: 6
  min_interval_hours: 24
  similarity_threshold: 0.82
  max_archived_per_pass: 20
```

## Safety properties

- **Deterministic** — no LLM call; uses the existing Jaccard helper, so it can't hallucinate or corrupt memory content.
- **PROFILE never touched** — identity memories are always kept.
- **Reversible** — archives (sets `is_archived`), never deletes; archived rows already exist and are excluded from retrieval.
- **Bounded** — throttled per chat (`min_interval_hours`) and capped (`max_archived_per_pass`).
- **Inert when disabled** — the loop isn't even spawned unless `enabled: true`.

## Changes

- `src/config.rs`: `SleepTimeConfig` (off by default) + field on `Config`.
- `src/memory_service.rs`: pure `select_duplicate_memories_to_archive()` (keeps best-first, excludes PROFILE, caps) + 5 unit tests.
- `src/scheduler.rs`: `spawn_memory_consolidation` / `run_memory_consolidation`, modeled on `spawn_idle_checkin`; reuses `list_idle_chats`, `get_all_memories_for_chat`, `archive_memory`.
- `src/runtime.rs`: boot the loop. `microclaw.config.example.yaml` + `CHANGELOG.md`: documented. `tests/config_validation.rs`: new field in the full-struct literal.

## Verification

- `cargo build` — clean.
- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo test --lib consolidation_tests::` — 5 passed; `cargo test --test config_validation` — 6 passed.

## Compatibility / rollback

No schema migration (reuses existing `is_archived`). No default behavior change (loop not spawned unless enabled). Clean revert.

---
https://claude.ai/code/session_0139tsJZ9v1Um6fNrP7K72MZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0139tsJZ9v1Um6fNrP7K72MZ)_