### PR TITLE
feat(eval): detect stuck loops and consecutive tool-error streaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,9 @@ The format is loosely based on Keep a Changelog. Dates use UTC.
   messages, or an object with a `messages` array) and checks trajectory health:
   no dangling `tool_use`, no orphaned `tool_result`, the session ends on a real answer
   (not a raw `tool_result`), tool-call count within `--max-tool-calls`, and tool errors
-  surfaced (failing only under `--strict-tool-errors`). Accepts a file or a directory of
+  surfaced (failing only under `--strict-tool-errors`). It also flags **stuck loops**
+  (the same tool + arguments repeated `--max-repeats` times) and **consecutive
+  tool-error streaks** (`--max-error-streak`). Accepts a file or a directory of
   fixtures, supports `--json`, and exits non-zero on failure so it can gate CI. Sample
   fixtures and usage in `docs/test/eval-fixtures/`. First slice of the v0.3.0 evaluation
   gate (Pillar 5). Enforced in CI via a "Trajectory eval gate" step that runs the

--- a/docs/test/eval-fixtures/README.md
+++ b/docs/test/eval-fixtures/README.md
@@ -29,8 +29,11 @@ microclaw eval docs/test/eval-fixtures/negative/dangling-tool-use.json
 - `no_orphan_tool_result` — every `tool_result` references a prior `tool_use`
 - `ends_with_answer` — the session ends on a real assistant answer, not a raw `tool_result`
 - `within_tool_budget` — tool-call count is within `--max-tool-calls`
+- `no_tool_call_loop` — the same tool + arguments isn't repeated `--max-repeats` times (stuck loop)
+- `no_error_streak` — no run of `--max-error-streak` consecutive tool errors
 - `tool_errors` — surfaces tool errors (fails only under `--strict-tool-errors`)
 
-`clean-session.json` passes all checks; `negative/dangling-tool-use.json` is the
-negative example — it ends with a `tool_use` that never received a `tool_result`,
-so it fails `no_dangling_tool_use`.
+`clean-session.json` passes all checks. Negative examples in `negative/`:
+`dangling-tool-use.json` ends with a `tool_use` that never received a
+`tool_result` (fails `no_dangling_tool_use`); `stuck-loop.json` repeats the same
+`bash ls` call three times (fails `no_tool_call_loop`).

--- a/docs/test/eval-fixtures/negative/stuck-loop.json
+++ b/docs/test/eval-fixtures/negative/stuck-loop.json
@@ -1,0 +1,12 @@
+{
+  "messages": [
+    { "role": "user", "content": "List the files." },
+    { "role": "assistant", "content": [ { "type": "tool_use", "id": "t1", "name": "bash", "input": { "command": "ls" } } ] },
+    { "role": "user", "content": [ { "type": "tool_result", "tool_use_id": "t1", "content": "a b c" } ] },
+    { "role": "assistant", "content": [ { "type": "tool_use", "id": "t2", "name": "bash", "input": { "command": "ls" } } ] },
+    { "role": "user", "content": [ { "type": "tool_result", "tool_use_id": "t2", "content": "a b c" } ] },
+    { "role": "assistant", "content": [ { "type": "tool_use", "id": "t3", "name": "bash", "input": { "command": "ls" } } ] },
+    { "role": "user", "content": [ { "type": "tool_result", "tool_use_id": "t3", "content": "a b c" } ] },
+    { "role": "assistant", "content": "Let me list the files again." }
+  ]
+}

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -88,19 +88,54 @@ fn is_pure_tool_result(msg: &Message) -> bool {
     }
 }
 
+/// Thresholds for the trajectory checks. Bundled so call sites and the CLI stay
+/// stable as more checks are added.
+#[derive(Debug, Clone)]
+pub struct EvalThresholds {
+    /// Maximum allowed tool calls per session.
+    pub max_tool_calls: usize,
+    /// Treat any tool error as a failure.
+    pub strict_tool_errors: bool,
+    /// Flag a stuck loop when the same (tool name + arguments) is called at least
+    /// this many times in a session.
+    pub max_repeats: usize,
+    /// Flag a session with at least this many consecutive tool errors.
+    pub max_error_streak: usize,
+}
+
+impl Default for EvalThresholds {
+    fn default() -> Self {
+        Self {
+            max_tool_calls: 100,
+            strict_tool_errors: false,
+            max_repeats: 3,
+            max_error_streak: 3,
+        }
+    }
+}
+
 /// Evaluate a single parsed session.
-pub fn evaluate(fixture: &str, messages: &[Message], max_tool_calls: usize, strict_tool_errors: bool) -> EvalReport {
+pub fn evaluate(fixture: &str, messages: &[Message], t: &EvalThresholds) -> EvalReport {
     // Walk blocks in order, tracking tool_use ids and which got a result.
     let mut tool_use_ids: Vec<String> = Vec::new();
     let mut resulted_ids: std::collections::HashSet<String> = std::collections::HashSet::new();
     let mut orphan_results: Vec<String> = Vec::new();
     let mut tool_errors = 0usize;
+    // (tool name + serialized args) -> occurrences, for stuck-loop detection.
+    let mut call_counts: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+    // Longest run of consecutive tool errors, in block order.
+    let mut error_streak = 0usize;
+    let mut cur_error_streak = 0usize;
 
     for msg in messages {
         let Some(bs) = blocks(msg) else { continue };
         for b in bs {
             match b {
-                ContentBlock::ToolUse { id, .. } => tool_use_ids.push(id.clone()),
+                ContentBlock::ToolUse { id, name, input, .. } => {
+                    tool_use_ids.push(id.clone());
+                    let key = format!("{name}\u{1f}{input}");
+                    *call_counts.entry(key).or_insert(0) += 1;
+                }
                 ContentBlock::ToolResult {
                     tool_use_id,
                     is_error,
@@ -113,12 +148,22 @@ pub fn evaluate(fixture: &str, messages: &[Message], max_tool_calls: usize, stri
                     }
                     if is_error.unwrap_or(false) {
                         tool_errors += 1;
+                        cur_error_streak += 1;
+                        error_streak = error_streak.max(cur_error_streak);
+                    } else {
+                        cur_error_streak = 0;
                     }
                 }
                 _ => {}
             }
         }
     }
+
+    let (top_call_key, top_call_count) = call_counts
+        .iter()
+        .max_by_key(|(_, c)| **c)
+        .map(|(k, c)| (k.clone(), *c))
+        .unwrap_or_default();
 
     let dangling: Vec<&String> = tool_use_ids
         .iter()
@@ -173,20 +218,51 @@ pub fn evaluate(fixture: &str, messages: &[Message], max_tool_calls: usize, stri
     });
 
     // 4. Tool-call budget.
-    let within_budget = tool_calls <= max_tool_calls;
+    let within_budget = tool_calls <= t.max_tool_calls;
     checks.push(CheckResult {
         name: "within_tool_budget".into(),
         passed: within_budget,
-        detail: format!("{tool_calls} tool calls (budget {max_tool_calls})"),
+        detail: format!("{tool_calls} tool calls (budget {})", t.max_tool_calls),
     });
 
     // 5. Tool errors — informational unless --strict-tool-errors.
     checks.push(CheckResult {
         name: "tool_errors".into(),
-        passed: !strict_tool_errors || tool_errors == 0,
+        passed: !t.strict_tool_errors || tool_errors == 0,
         detail: format!(
             "{tool_errors} tool error(s){}",
-            if strict_tool_errors { " (strict)" } else { " (informational)" }
+            if t.strict_tool_errors { " (strict)" } else { " (informational)" }
+        ),
+    });
+
+    // 6. No stuck loop — the same (tool + arguments) repeated too many times.
+    let no_loop = top_call_count < t.max_repeats.max(1);
+    let top_tool = top_call_key
+        .split('\u{1f}')
+        .next()
+        .unwrap_or("")
+        .to_string();
+    checks.push(CheckResult {
+        name: "no_tool_call_loop".into(),
+        passed: no_loop,
+        detail: if no_loop {
+            format!("max identical tool call repeated {top_call_count}x (limit {})", t.max_repeats)
+        } else {
+            format!(
+                "tool '{top_tool}' called with identical arguments {top_call_count}x (limit {})",
+                t.max_repeats
+            )
+        },
+    });
+
+    // 7. No long consecutive tool-error streak.
+    let no_error_streak = error_streak < t.max_error_streak.max(1);
+    checks.push(CheckResult {
+        name: "no_error_streak".into(),
+        passed: no_error_streak,
+        detail: format!(
+            "longest consecutive tool-error streak {error_streak} (limit {})",
+            t.max_error_streak
         ),
     });
 
@@ -220,7 +296,7 @@ fn collect_fixtures(path: &Path) -> Result<Vec<PathBuf>> {
 }
 
 /// CLI entry point. Returns the process exit code (0 = all passed, 1 = failure).
-pub fn run_eval(path: &str, max_tool_calls: usize, strict_tool_errors: bool, json: bool) -> Result<i32> {
+pub fn run_eval(path: &str, thresholds: &EvalThresholds, json: bool) -> Result<i32> {
     let fixtures = collect_fixtures(Path::new(path))?;
     if fixtures.is_empty() {
         anyhow::bail!("no .json fixtures found at {path}");
@@ -232,12 +308,7 @@ pub fn run_eval(path: &str, max_tool_calls: usize, strict_tool_errors: bool, jso
             .with_context(|| format!("reading fixture {}", f.display()))?;
         let messages = load_messages(&raw)
             .with_context(|| format!("parsing fixture {}", f.display()))?;
-        reports.push(evaluate(
-            &f.display().to_string(),
-            &messages,
-            max_tool_calls,
-            strict_tool_errors,
-        ));
+        reports.push(evaluate(&f.display().to_string(), &messages, thresholds));
     }
 
     let all_passed = reports.iter().all(|r| r.passed);
@@ -296,6 +367,19 @@ mod tests {
         }
     }
 
+    /// A tool_use with an explicit name + input (for loop detection tests).
+    fn assistant_tool_use_named(id: &str, name: &str, input: serde_json::Value) -> Message {
+        Message {
+            role: "assistant".into(),
+            content: MessageContent::Blocks(vec![ContentBlock::ToolUse {
+                id: id.into(),
+                name: name.into(),
+                input,
+                thought_signature: None,
+            }]),
+        }
+    }
+
     fn tool_result(id: &str, is_error: bool) -> Message {
         Message {
             role: "user".into(),
@@ -307,6 +391,14 @@ mod tests {
         }
     }
 
+    fn th(max_tool_calls: usize, strict: bool) -> EvalThresholds {
+        EvalThresholds {
+            max_tool_calls,
+            strict_tool_errors: strict,
+            ..EvalThresholds::default()
+        }
+    }
+
     #[test]
     fn clean_trajectory_passes() {
         let msgs = vec![
@@ -315,7 +407,7 @@ mod tests {
             tool_result("t1", false),
             assistant_text("here is the answer"),
         ];
-        let r = evaluate("clean", &msgs, 100, false);
+        let r = evaluate("clean", &msgs, &th(100, false));
         assert!(r.passed, "checks: {:?}", r.checks);
         assert_eq!(r.tool_calls, 1);
     }
@@ -326,7 +418,7 @@ mod tests {
             Message { role: "user".into(), content: MessageContent::Text("hi".into()) },
             assistant_tool_use("t1"), // no result
         ];
-        let r = evaluate("dangling", &msgs, 100, false);
+        let r = evaluate("dangling", &msgs, &th(100, false));
         assert!(!r.passed);
         assert!(r.checks.iter().any(|c| c.name == "no_dangling_tool_use" && !c.passed));
     }
@@ -337,21 +429,22 @@ mod tests {
             assistant_tool_use("t1"),
             tool_result("t1", false), // session ends on a tool_result
         ];
-        let r = evaluate("ends_tr", &msgs, 100, false);
+        let r = evaluate("ends_tr", &msgs, &th(100, false));
         assert!(!r.passed);
         assert!(r.checks.iter().any(|c| c.name == "ends_with_answer" && !c.passed));
     }
 
     #[test]
     fn over_budget_fails() {
+        // Distinct inputs so we exercise the budget check, not the loop check.
         let msgs = vec![
-            assistant_tool_use("t1"),
+            assistant_tool_use_named("t1", "read_file", serde_json::json!({"p": "a"})),
             tool_result("t1", false),
-            assistant_tool_use("t2"),
+            assistant_tool_use_named("t2", "read_file", serde_json::json!({"p": "b"})),
             tool_result("t2", false),
             assistant_text("done"),
         ];
-        let r = evaluate("budget", &msgs, 1, false);
+        let r = evaluate("budget", &msgs, &th(1, false));
         assert!(!r.passed);
         assert!(r.checks.iter().any(|c| c.name == "within_tool_budget" && !c.passed));
     }
@@ -359,7 +452,7 @@ mod tests {
     #[test]
     fn orphan_tool_result_fails() {
         let msgs = vec![tool_result("ghost", false), assistant_text("done")];
-        let r = evaluate("orphan", &msgs, 100, false);
+        let r = evaluate("orphan", &msgs, &th(100, false));
         assert!(!r.passed);
         assert!(r.checks.iter().any(|c| c.name == "no_orphan_tool_result" && !c.passed));
     }
@@ -371,11 +464,59 @@ mod tests {
             tool_result("t1", true),
             assistant_text("recovered"),
         ];
-        let lenient = evaluate("err", &msgs, 100, false);
+        let lenient = evaluate("err", &msgs, &th(100, false));
         assert!(lenient.passed, "errors should be informational: {:?}", lenient.checks);
         assert_eq!(lenient.tool_errors, 1);
-        let strict = evaluate("err", &msgs, 100, true);
+        let strict = evaluate("err", &msgs, &th(100, true));
         assert!(!strict.passed);
+    }
+
+    #[test]
+    fn stuck_loop_fails() {
+        // Same tool + identical arguments three times trips the loop check.
+        let msgs = vec![
+            assistant_tool_use_named("t1", "bash", serde_json::json!({"cmd": "ls"})),
+            tool_result("t1", false),
+            assistant_tool_use_named("t2", "bash", serde_json::json!({"cmd": "ls"})),
+            tool_result("t2", false),
+            assistant_tool_use_named("t3", "bash", serde_json::json!({"cmd": "ls"})),
+            tool_result("t3", false),
+            assistant_text("stuck"),
+        ];
+        let r = evaluate("loop", &msgs, &th(100, false));
+        assert!(!r.passed);
+        assert!(r.checks.iter().any(|c| c.name == "no_tool_call_loop" && !c.passed));
+    }
+
+    #[test]
+    fn distinct_args_do_not_trip_loop() {
+        let msgs = vec![
+            assistant_tool_use_named("t1", "bash", serde_json::json!({"cmd": "ls a"})),
+            tool_result("t1", false),
+            assistant_tool_use_named("t2", "bash", serde_json::json!({"cmd": "ls b"})),
+            tool_result("t2", false),
+            assistant_tool_use_named("t3", "bash", serde_json::json!({"cmd": "ls c"})),
+            tool_result("t3", false),
+            assistant_text("done"),
+        ];
+        let r = evaluate("noloop", &msgs, &th(100, false));
+        assert!(r.passed, "checks: {:?}", r.checks);
+    }
+
+    #[test]
+    fn error_streak_fails() {
+        let msgs = vec![
+            assistant_tool_use_named("t1", "bash", serde_json::json!({"c": 1})),
+            tool_result("t1", true),
+            assistant_tool_use_named("t2", "bash", serde_json::json!({"c": 2})),
+            tool_result("t2", true),
+            assistant_tool_use_named("t3", "bash", serde_json::json!({"c": 3})),
+            tool_result("t3", true),
+            assistant_text("gave up"),
+        ];
+        let r = evaluate("streak", &msgs, &th(100, false));
+        assert!(!r.passed);
+        assert!(r.checks.iter().any(|c| c.name == "no_error_streak" && !c.passed));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,6 +88,12 @@ struct EvalCommand {
     /// Maximum allowed tool calls per session before flagging
     #[arg(long, default_value_t = 100)]
     max_tool_calls: usize,
+    /// Flag a stuck loop when the same tool + arguments is called this many times
+    #[arg(long, default_value_t = 3)]
+    max_repeats: usize,
+    /// Flag this many consecutive tool errors as a failure
+    #[arg(long, default_value_t = 3)]
+    max_error_streak: usize,
     /// Treat tool errors in the trajectory as a failure
     #[arg(long)]
     strict_tool_errors: bool,
@@ -633,12 +639,13 @@ async fn main() -> anyhow::Result<()> {
             return Ok(());
         }
         Some(MainCommand::Eval(eval_args)) => {
-            let code = eval::run_eval(
-                &eval_args.path,
-                eval_args.max_tool_calls,
-                eval_args.strict_tool_errors,
-                eval_args.json,
-            )?;
+            let thresholds = eval::EvalThresholds {
+                max_tool_calls: eval_args.max_tool_calls,
+                strict_tool_errors: eval_args.strict_tool_errors,
+                max_repeats: eval_args.max_repeats,
+                max_error_streak: eval_args.max_error_streak,
+            };
+            let code = eval::run_eval(&eval_args.path, &thresholds, eval_args.json)?;
             std::process::exit(code);
         }
         Some(MainCommand::Reembed) => {


### PR DESCRIPTION
Closes #413. Follow-up to #408/#410.

## What

Extends the `microclaw eval` gate with two deterministic checks for trajectory pathologies the structural checks miss:

- `no_tool_call_loop` — the same `(tool name + arguments)` repeated ≥ `--max-repeats` (default 3) → stuck loop.
- `no_error_streak` — a run of ≥ `--max-error-streak` (default 3) consecutive tool errors.

Thresholds are bundled into an `EvalThresholds` struct so call sites and the CLI stay stable as more checks land.

```
$ microclaw eval docs/test/eval-fixtures/negative/stuck-loop.json
FAIL .../stuck-loop.json  (8 msgs, 3 tool calls, 0 errors)
    - no_tool_call_loop: tool 'bash' called with identical arguments 3x (limit 3)
```

## Changes

- `src/eval.rs`: `EvalThresholds` struct; collect per-call `(name+args)` counts and the longest consecutive error streak; two new checks; tests for loop / distinct-args / error-streak (11 eval tests total).
- `src/main.rs`: `--max-repeats` and `--max-error-streak` flags; build `EvalThresholds`.
- `docs/test/eval-fixtures/negative/stuck-loop.json`: new negative fixture; README + CHANGELOG updated.

## Verification

- `cargo build` + `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo test --lib eval::` — 11 passed.
- `microclaw eval docs/test/eval-fixtures` → exit 0 (CI-gated set still green); stuck-loop fixture → exit 1.

## Compatibility / rollback

Additive to the eval CLI only. No runtime/agent change, no schema. Defaults keep prior fixtures passing. Clean revert.

---
https://claude.ai/code/session_0139tsJZ9v1Um6fNrP7K72MZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0139tsJZ9v1Um6fNrP7K72MZ)_