### PR TITLE
feat(config): finish aux_models slots — title and vision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ The format is loosely based on Keep a Changelog. Dates use UTC.
   - `aux_models.compaction` — context/history summarization.
   - `aux_models.reflector` — the background memory reflector (fact/triple extraction),
     which runs periodically per active chat.
+  - `aux_models.title` — one-shot session-title generation.
+  - `aux_models.vision` — image description (the `describe_image` tool); overrides
+    `media.vision.model` when set, and an explicit per-call `model` argument still wins.
+
+  (`session_search` has no LLM step — it is pure full-text search — so it has no slot.)
 
   Each auxiliary model reuses the main provider profile and credentials — only the
   model name is swapped — and falls back to the main model when unset, so default

--- a/microclaw.config.example.yaml
+++ b/microclaw.config.example.yaml
@@ -30,6 +30,8 @@ max_tool_iterations: 100
 # aux_models:
 #   compaction: claude-haiku-4-5   # cheaper model for context/history summarization
 #   reflector: claude-haiku-4-5    # cheaper model for the background memory reflector
+#   title: claude-haiku-4-5        # cheaper model for short session-title generation
+#   vision: claude-haiku-4-5       # model for image description (overrides media.vision.model)
 # Inject pending messages into the active agent loop between iterations (mid-turn injection)
 enable_mid_turn_injection: true
 # On non-web channels (Telegram, Discord, Slack, Feishu, Matrix, WeChat),

--- a/src/config.rs
+++ b/src/config.rs
@@ -789,6 +789,15 @@ pub struct AuxModels {
     /// Falls back to the main model when unset or empty.
     #[serde(default)]
     pub reflector: Option<String>,
+    /// Model used to generate short session titles. This is a one-shot
+    /// summarization, so a cheaper model is pure savings. Falls back to the
+    /// provider's default model when unset or empty.
+    #[serde(default)]
+    pub title: Option<String>,
+    /// Model used for image description (the `describe_image` tool). Overrides
+    /// `media.vision.model` when set; falls back to it when unset or empty.
+    #[serde(default)]
+    pub vision: Option<String>,
 }
 
 impl AuxModels {
@@ -805,6 +814,24 @@ impl AuxModels {
     /// provider's default model) when unset or empty, preserving prior behavior.
     pub fn reflector_model(&self) -> Option<&str> {
         match self.reflector.as_deref() {
+            Some(m) if !m.trim().is_empty() => Some(m),
+            _ => None,
+        }
+    }
+
+    /// Optional model override for session-title generation. Returns `None` (use
+    /// the provider's default model) when unset or empty, preserving prior behavior.
+    pub fn title_model(&self) -> Option<&str> {
+        match self.title.as_deref() {
+            Some(m) if !m.trim().is_empty() => Some(m),
+            _ => None,
+        }
+    }
+
+    /// Optional model override for image description. Returns `None` (use
+    /// `media.vision.model`) when unset or empty, preserving prior behavior.
+    pub fn vision_model(&self) -> Option<&str> {
+        match self.vision.as_deref() {
             Some(m) if !m.trim().is_empty() => Some(m),
             _ => None,
         }
@@ -2888,6 +2915,43 @@ mod tests {
         let yaml = "telegram_bot_token: tok\nbot_username: bot\napi_key: key\n";
         let config: Config = serde_yaml::from_str(yaml).unwrap();
         assert!(config.aux_models.compaction.is_none());
+    }
+
+    #[test]
+    fn aux_models_title_and_vision_default_none() {
+        let aux = AuxModels::default();
+        assert_eq!(aux.title_model(), None);
+        assert_eq!(aux.vision_model(), None);
+    }
+
+    #[test]
+    fn aux_models_title_and_vision_override_used() {
+        let aux = AuxModels {
+            title: Some("title-model".to_string()),
+            vision: Some("vision-model".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(aux.title_model(), Some("title-model"));
+        assert_eq!(aux.vision_model(), Some("vision-model"));
+    }
+
+    #[test]
+    fn aux_models_title_and_vision_blank_is_none() {
+        let aux = AuxModels {
+            title: Some("  ".to_string()),
+            vision: Some(String::new()),
+            ..Default::default()
+        };
+        assert_eq!(aux.title_model(), None);
+        assert_eq!(aux.vision_model(), None);
+    }
+
+    #[test]
+    fn aux_models_title_vision_parse_from_yaml() {
+        let yaml = "telegram_bot_token: tok\nbot_username: bot\napi_key: key\naux_models:\n  title: claude-haiku-4-5\n  vision: claude-haiku-4-5\n";
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(config.aux_models.title_model(), Some("claude-haiku-4-5"));
+        assert_eq!(config.aux_models.vision_model(), Some("claude-haiku-4-5"));
     }
 
     #[test]

--- a/src/title_generator.rs
+++ b/src/title_generator.rs
@@ -56,14 +56,17 @@ pub async fn generate_and_save_title(
     let user = format!(
         "Produce a title for the following conversation. Reply with the title only.\n\n{transcript}"
     );
+    // Title generation is one-shot summarization, so allow a (typically cheaper)
+    // auxiliary model. Passing `None` when unset preserves the prior behavior.
     let response = provider
-        .send_message(
+        .send_message_with_model(
             &system,
             vec![Message {
                 role: "user".to_string(),
                 content: MessageContent::Text(user),
             }],
             None,
+            config.aux_models.title_model(),
         )
         .await?;
     let title = first_text(&response.content)

--- a/src/tools/describe_image.rs
+++ b/src/tools/describe_image.rs
@@ -21,6 +21,8 @@ pub struct DescribeImageTool {
     openai_api_key: Option<String>,
     openai_base_url: Option<String>,
     timeout_secs: u64,
+    /// Optional `aux_models.vision` override, applied over `cfg.model` when set.
+    vision_aux: Option<String>,
 }
 
 impl DescribeImageTool {
@@ -38,6 +40,7 @@ impl DescribeImageTool {
             openai_api_key: config.openai_api_key.clone(),
             openai_base_url: config.openai_base_url.clone(),
             timeout_secs: config.tool_timeout_secs("describe_image", 60),
+            vision_aux: config.aux_models.vision_model().map(|s| s.to_string()),
         }
     }
 
@@ -107,10 +110,12 @@ impl Tool for DescribeImageTool {
             .unwrap_or("Describe this image in detail.")
             .trim()
             .to_string();
+        // Resolution: explicit tool input > aux_models.vision > media.vision.model.
         let model = input
             .get("model")
             .and_then(|v| v.as_str())
             .map(|s| s.to_string())
+            .or_else(|| self.vision_aux.clone())
             .unwrap_or_else(|| self.cfg.model.clone());
 
         let client = match self.client() {


### PR DESCRIPTION
Follow-up to #403/#406. Finishes Pillar 3 (per-task auxiliary models) of the v0.3.0 plan.

## What

Wires the remaining `aux_models` slots to their live call sites, mirroring the existing `compaction`/`reflector` pattern — same provider and credentials, only the model name is swapped, and an unset/blank slot leaves behavior exactly as before:

- **`aux_models.title`** → session-title generation (`title_generator.rs`), now via `send_message_with_model(.., title_model())`.
- **`aux_models.vision`** → image description (`describe_image` tool); overrides `media.vision.model` when set, while an explicit per-call `model` argument still wins (precedence: input `model` > `aux_models.vision` > `media.vision.model`).

`session_search` has **no LLM step** — it is pure FTS5 full-text search — so there is nothing to route and it gets no slot (noted in the CHANGELOG).

## Changes

- `src/config.rs`: `title` + `vision` fields on `AuxModels`; `title_model()` / `vision_model()` helpers returning `Option<&str>` (mirroring `reflector_model()`); 4 new unit tests.
- `src/title_generator.rs`: one-shot title call routed through `title_model()`.
- `src/tools/describe_image.rs`: new `vision_aux` field from `aux_models.vision`, applied in model resolution.
- `microclaw.config.example.yaml`, `CHANGELOG.md` updated.

## Verification

- `cargo build` + `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo test --lib aux_models` — 11 passed.
- Behavior unchanged when slots are unset/blank (helpers return `None`; describe_image falls back to `media.vision.model`).

## Compatibility / rollback

Additive, opt-in config. Defaults preserve current behavior exactly. No schema, no runtime change beyond model-name selection. Clean revert.

---
https://claude.ai/code/session_0139tsJZ9v1Um6fNrP7K72MZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0139tsJZ9v1Um6fNrP7K72MZ)_