### PR TITLE
feat(audit): tamper-evident hash-chained audit log + verify CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ The format is loosely based on Keep a Changelog. Dates use UTC.
     `media.vision.model` when set, and an explicit per-call `model` argument still wins.
 
   (`session_search` has no LLM step — it is pure full-text search — so it has no slot.)
+- Tamper-evident audit log — every new `audit_logs` entry is now sealed into a SHA-256
+  hash chain (`entry_hash` over the entry's fields plus the previous entry's `entry_hash`,
+  with a genesis link for the first). Modifying a field, deleting a row, or reordering rows
+  breaks the chain. A new `microclaw audit verify` command walks the chain and reports the
+  first broken link (exiting non-zero so it can gate monitoring/CI), and `microclaw audit
+  list [--kind] [--limit]` prints recent entries. Sealing happens under the DB connection
+  lock so concurrent writers can't race the chain; pre-migration rows stay unsealed and are
+  simply excluded from verification. First slice of the v0.4.0 security-governance track
+  (tamper-evident audit).
 
   Each auxiliary model reuses the main provider profile and credentials — only the
   model name is swapped — and falls back to the main model when unset, so default

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2907,6 +2907,7 @@ dependencies = [
  "microclaw-core",
  "rusqlite",
  "serde_json",
+ "sha2",
  "sqlite-vec",
  "tokio",
  "uuid",

--- a/crates/microclaw-storage/Cargo.toml
+++ b/crates/microclaw-storage/Cargo.toml
@@ -13,6 +13,7 @@ chrono = { version = "0.4", features = ["serde"] }
 microclaw-core = { version = "0.1.0", path = "../microclaw-core" }
 rusqlite = { version = "0.37", features = ["bundled"] }
 serde_json = "1"
+sha2 = "0.10"
 tokio = { version = "1", features = ["full"] }
 uuid = { version = "1", features = ["v4"] }
 sqlite-vec = { version = "0.1.8-alpha.1", optional = true }

--- a/crates/microclaw-storage/src/db.rs
+++ b/crates/microclaw-storage/src/db.rs
@@ -234,7 +234,11 @@ pub struct AuditLogRecord {
 pub type SessionMetaRow = (String, String, Option<String>, Option<i64>);
 pub type SessionTreeRow = (i64, Option<String>, Option<i64>, String);
 
-const SCHEMA_VERSION_CURRENT: i64 = 26;
+const SCHEMA_VERSION_CURRENT: i64 = 27;
+
+/// Genesis link for the tamper-evident audit hash chain — the `prev_hash` of the
+/// first sealed entry.
+const AUDIT_GENESIS_HASH: &str = "GENESIS";
 
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
@@ -1075,10 +1079,95 @@ fn apply_schema_migrations(conn: &Connection) -> Result<(), MicroClawError> {
         set_schema_version(conn, 26)?;
         version = 26;
     }
+    if version < 27 {
+        // Tamper-evident audit log: each new entry is sealed into a SHA-256 hash
+        // chain (`entry_hash` over the entry's fields plus the previous entry's
+        // `entry_hash`). Existing pre-migration rows stay unsealed (NULL) and are
+        // simply not part of the verifiable chain.
+        if !table_has_column(conn, "audit_logs", "prev_hash")? {
+            conn.execute("ALTER TABLE audit_logs ADD COLUMN prev_hash TEXT", [])?;
+        }
+        if !table_has_column(conn, "audit_logs", "entry_hash")? {
+            conn.execute("ALTER TABLE audit_logs ADD COLUMN entry_hash TEXT", [])?;
+        }
+        set_schema_version(conn, 27)?;
+        version = 27;
+    }
     if version != SCHEMA_VERSION_CURRENT {
         set_schema_version(conn, SCHEMA_VERSION_CURRENT)?;
     }
     Ok(())
+}
+
+/// Lowercase hex of a byte slice (avoids pulling in the `hex` crate).
+fn to_hex(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+/// Compute the sealing hash for an audit entry: SHA-256 over the previous
+/// entry's hash followed by this entry's content fields, each `\x1f`-terminated
+/// so field boundaries can't be ambiguous. The chain link in `prev_hash` makes
+/// deletion or reordering detectable; covering every field makes in-place edits
+/// detectable.
+#[allow(clippy::too_many_arguments)]
+fn audit_entry_hash(
+    prev_hash: &str,
+    kind: &str,
+    actor: &str,
+    action: &str,
+    target: Option<&str>,
+    status: &str,
+    detail: Option<&str>,
+    created_at: &str,
+) -> String {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    for field in [
+        prev_hash,
+        kind,
+        actor,
+        action,
+        target.unwrap_or(""),
+        status,
+        detail.unwrap_or(""),
+        created_at,
+    ] {
+        h.update(field.as_bytes());
+        h.update([0x1f]);
+    }
+    to_hex(&h.finalize())
+}
+
+/// A sealed audit row as read for chain verification: id + content fields +
+/// `prev_hash` + `entry_hash`.
+type AuditChainRow = (
+    i64,
+    String,
+    String,
+    String,
+    Option<String>,
+    String,
+    Option<String>,
+    String,
+    Option<String>,
+    String,
+);
+
+/// Result of verifying the audit hash chain.
+#[derive(Debug, Clone)]
+pub struct AuditChainStatus {
+    /// Number of sealed (hash-bearing) entries inspected.
+    pub sealed_entries: usize,
+    /// Whether the chain is fully intact.
+    pub intact: bool,
+    /// The `id` of the first entry where verification failed, if any.
+    pub broken_at: Option<i64>,
+    /// Human-readable reason for the break, if any.
+    pub reason: Option<String>,
 }
 
 impl Database {
@@ -2971,12 +3060,102 @@ impl Database {
     ) -> Result<i64, MicroClawError> {
         let conn = self.lock_conn();
         let now = chrono::Utc::now().to_rfc3339();
+        // Seal the entry into the hash chain. Reading the latest sealed hash and
+        // inserting happen under the same connection lock, so concurrent callers
+        // can't race the chain.
+        let prev_hash: String = conn
+            .query_row(
+                "SELECT entry_hash FROM audit_logs
+                 WHERE entry_hash IS NOT NULL
+                 ORDER BY id DESC LIMIT 1",
+                [],
+                |row| row.get(0),
+            )
+            .optional()?
+            .unwrap_or_else(|| AUDIT_GENESIS_HASH.to_string());
+        let entry_hash = audit_entry_hash(
+            &prev_hash, kind, actor, action, target, status, detail, &now,
+        );
         conn.execute(
-            "INSERT INTO audit_logs(kind, actor, action, target, status, detail, created_at)
-             VALUES(?1, ?2, ?3, ?4, ?5, ?6, ?7)",
-            params![kind, actor, action, target, status, detail, now],
+            "INSERT INTO audit_logs(kind, actor, action, target, status, detail, created_at, prev_hash, entry_hash)
+             VALUES(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            params![kind, actor, action, target, status, detail, now, prev_hash, entry_hash],
         )?;
         Ok(conn.last_insert_rowid())
+    }
+
+    /// Verify the tamper-evident audit hash chain. Walks all sealed entries in
+    /// `id` order, checking that each links to the previous (`prev_hash`) and
+    /// that its `entry_hash` still matches its content. Returns the first break,
+    /// if any. Unsealed legacy rows (NULL `entry_hash`) are ignored.
+    pub fn verify_audit_chain(&self) -> Result<AuditChainStatus, MicroClawError> {
+        let conn = self.lock_conn();
+        let mut stmt = conn.prepare(
+            "SELECT id, kind, actor, action, target, status, detail, created_at, prev_hash, entry_hash
+             FROM audit_logs
+             WHERE entry_hash IS NOT NULL
+             ORDER BY id ASC",
+        )?;
+        // Collect first so the statement borrow is released before we iterate.
+        let rows: Vec<AuditChainRow> =
+            stmt.query_map([], |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                    row.get(5)?,
+                    row.get(6)?,
+                    row.get(7)?,
+                    row.get(8)?,
+                    row.get(9)?,
+                ))
+            })?
+            .collect::<Result<_, _>>()?;
+
+        let mut expected_prev = AUDIT_GENESIS_HASH.to_string();
+        let mut sealed = 0usize;
+        for (id, kind, actor, action, target, status, detail, created_at, prev_hash, entry_hash) in &rows {
+            sealed += 1;
+            let prev = prev_hash.as_deref().unwrap_or("");
+            if prev != expected_prev {
+                return Ok(AuditChainStatus {
+                    sealed_entries: sealed,
+                    intact: false,
+                    broken_at: Some(*id),
+                    reason: Some(
+                        "prev_hash does not link to the previous entry (an entry was deleted, inserted, or reordered)".to_string(),
+                    ),
+                });
+            }
+            let recomputed = audit_entry_hash(
+                prev,
+                kind,
+                actor,
+                action,
+                target.as_deref(),
+                status,
+                detail.as_deref(),
+                created_at,
+            );
+            if &recomputed != entry_hash {
+                return Ok(AuditChainStatus {
+                    sealed_entries: sealed,
+                    intact: false,
+                    broken_at: Some(*id),
+                    reason: Some("entry_hash does not match content (an entry was modified)".to_string()),
+                });
+            }
+            expected_prev = entry_hash.clone();
+        }
+
+        Ok(AuditChainStatus {
+            sealed_entries: sealed,
+            intact: true,
+            broken_at: None,
+            reason: None,
+        })
     }
 
     pub fn list_audit_logs(
@@ -5654,6 +5833,58 @@ mod tests {
 
     fn cleanup(dir: &std::path::Path) {
         let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn audit_chain_intact_after_appends() {
+        let (db, dir) = test_db();
+        db.log_audit_event("auth", "alice", "login", None, "ok", None).unwrap();
+        db.log_audit_event("tool", "bot", "web_fetch", Some("https://x"), "ok", Some("200")).unwrap();
+        db.log_audit_event("auth", "alice", "logout", None, "ok", None).unwrap();
+        let status = db.verify_audit_chain().unwrap();
+        assert!(status.intact, "reason: {:?}", status.reason);
+        assert_eq!(status.sealed_entries, 3);
+        assert_eq!(status.broken_at, None);
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn audit_chain_detects_modification() {
+        let (db, dir) = test_db();
+        db.log_audit_event("auth", "alice", "login", None, "ok", None).unwrap();
+        let id = db
+            .log_audit_event("tool", "bot", "web_fetch", Some("https://x"), "ok", None)
+            .unwrap();
+        db.log_audit_event("auth", "alice", "logout", None, "ok", None).unwrap();
+        {
+            let conn = db.lock_conn();
+            conn.execute("UPDATE audit_logs SET status='tampered' WHERE id=?1", params![id])
+                .unwrap();
+        }
+        let status = db.verify_audit_chain().unwrap();
+        assert!(!status.intact);
+        assert_eq!(status.broken_at, Some(id));
+        assert!(status.reason.unwrap().contains("modified"));
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn audit_chain_detects_deletion() {
+        let (db, dir) = test_db();
+        db.log_audit_event("auth", "alice", "login", None, "ok", None).unwrap();
+        let id = db
+            .log_audit_event("tool", "bot", "web_fetch", Some("https://x"), "ok", None)
+            .unwrap();
+        db.log_audit_event("auth", "alice", "logout", None, "ok", None).unwrap();
+        {
+            let conn = db.lock_conn();
+            conn.execute("DELETE FROM audit_logs WHERE id=?1", params![id]).unwrap();
+        }
+        let status = db.verify_audit_chain().unwrap();
+        assert!(!status.intact);
+        assert!(status.broken_at.is_some());
+        assert!(status.reason.unwrap().contains("deleted"));
+        cleanup(&dir);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,6 +73,8 @@ enum MainCommand {
     Web(WebCommand),
     /// Evaluate recorded session trajectories (CI gate; no LLM call)
     Eval(EvalCommand),
+    /// Inspect and verify the tamper-evident audit log
+    Audit(AuditCommand),
     /// Re-embed active memories (requires `sqlite-vec` feature)
     Reembed,
     /// Upgrade MicroClaw to latest release
@@ -100,6 +102,27 @@ struct EvalCommand {
     /// Emit a JSON report instead of human-readable text
     #[arg(long)]
     json: bool,
+}
+
+#[derive(Debug, Args)]
+struct AuditCommand {
+    #[command(subcommand)]
+    action: AuditAction,
+}
+
+#[derive(Debug, Subcommand)]
+enum AuditAction {
+    /// Verify the tamper-evident hash chain over the audit log
+    Verify,
+    /// List recent audit-log entries
+    List {
+        /// Filter by event kind (e.g. `auth`, `tool`, `hook`)
+        #[arg(long)]
+        kind: Option<String>,
+        /// Maximum number of entries to show
+        #[arg(long, default_value_t = 50)]
+        limit: usize,
+    },
 }
 
 #[derive(Debug, Args)]
@@ -519,6 +542,56 @@ fn apply_config_override(path: Option<&PathBuf>) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Handle `microclaw audit <verify|list>`. Returns the process exit code:
+/// 0 when the chain is intact (or for `list`), 1 when tampering is detected.
+fn handle_audit_cli(cmd: AuditCommand) -> anyhow::Result<i32> {
+    let config = Config::load()?;
+    let db = db::Database::new(&config.runtime_data_dir())?;
+    match cmd.action {
+        AuditAction::Verify => {
+            let status = db.verify_audit_chain()?;
+            if status.intact {
+                println!(
+                    "Audit chain intact: {} sealed entr{} verified.",
+                    status.sealed_entries,
+                    if status.sealed_entries == 1 { "y" } else { "ies" }
+                );
+                Ok(0)
+            } else {
+                eprintln!(
+                    "Audit chain BROKEN at entry id {}: {}",
+                    status.broken_at.unwrap_or(-1),
+                    status.reason.as_deref().unwrap_or("unknown"),
+                );
+                eprintln!("({} entr{} verified before the break)",
+                    status.sealed_entries.saturating_sub(1),
+                    if status.sealed_entries.saturating_sub(1) == 1 { "y" } else { "ies" });
+                Ok(1)
+            }
+        }
+        AuditAction::List { kind, limit } => {
+            let rows = db.list_audit_logs(kind.as_deref(), limit)?;
+            if rows.is_empty() {
+                println!("No audit-log entries.");
+            } else {
+                for r in &rows {
+                    println!(
+                        "[{}] {} {} {} {} target={} {}",
+                        r.created_at,
+                        r.kind,
+                        r.actor,
+                        r.action,
+                        r.status,
+                        r.target.as_deref().unwrap_or("-"),
+                        r.detail.as_deref().unwrap_or(""),
+                    );
+                }
+            }
+            Ok(0)
+        }
+    }
+}
+
 async fn reembed_memories() -> anyhow::Result<()> {
     let config = Config::load()?;
 
@@ -646,6 +719,10 @@ async fn main() -> anyhow::Result<()> {
                 max_error_streak: eval_args.max_error_streak,
             };
             let code = eval::run_eval(&eval_args.path, &thresholds, eval_args.json)?;
+            std::process::exit(code);
+        }
+        Some(MainCommand::Audit(audit_args)) => {
+            let code = handle_audit_cli(audit_args)?;
             std::process::exit(code);
         }
         Some(MainCommand::Reembed) => {


### PR DESCRIPTION
First slice of the v0.4.0 **security-governance** track (Track B): tamper-evident audit logging.

## What

The `audit_logs` table records auth/web/hook events but had no integrity protection — a row could be silently modified or deleted. This seals every new entry into a **SHA-256 hash chain**:

```
entry_hash = SHA256( prev_hash ‖ kind ‖ actor ‖ action ‖ target ‖ status ‖ detail ‖ created_at )
```

each field `\x1f`-terminated, `prev_hash` = the previous entry's `entry_hash` (genesis link for the first). Modifying any field breaks that row's `entry_hash`; deleting or reordering rows breaks the next row's `prev_hash` link. Either way `verify` pinpoints the first broken entry.

```
$ microclaw audit verify
Audit chain intact: 1423 sealed entries verified.

# after tampering:
$ microclaw audit verify
Audit chain BROKEN at entry id 871: entry_hash does not match content (an entry was modified)
(870 entries verified before the break)
```

## Changes

- **storage** (`crates/microclaw-storage`): adds `sha2`; schema **v27** adds `prev_hash`/`entry_hash` (backward compatible — `ALTER TABLE … ADD COLUMN` behind `table_has_column` guards; pre-migration rows stay unsealed and are excluded from verification). `log_audit_event` reads the latest sealed hash and inserts **under the same connection lock**, so concurrent writers can't race the chain. New `verify_audit_chain() -> AuditChainStatus` walks all sealed rows in `id` order and returns the first break.
- **CLI** (`src/main.rs`): `microclaw audit verify` (exits non-zero on tampering, for monitoring/CI) and `microclaw audit list [--kind] [--limit]`.

## Verification

- `cargo build` + `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo test -p microclaw-storage` — 95 passed, incl. 3 new tests covering an intact chain, an in-place modification (detected at the right id with an "modified" reason), and a deletion (detected via the broken `prev_hash` link).
- CLI verified end-to-end on an empty DB (`intact: 0 sealed entries`, exit 0); migration columns confirmed present.

## Compatibility / rollback

Additive migration; no behavior change to logging callers (the seal is computed inside `log_audit_event`). Legacy rows remain readable and are simply not part of the verifiable chain. Clean revert (the columns are nullable and unused by a reverted binary).

---
https://claude.ai/code/session_0139tsJZ9v1Um6fNrP7K72MZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0139tsJZ9v1Um6fNrP7K72MZ)_