### PR TITLE
feat(doctor): surface misconfigured channels with actionable messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is loosely based on Keep a Changelog. Dates use UTC.
 
 ### Added
 
+- Clearer "no channel enabled" diagnostics — the common trap of filling in a channel's
+  credentials but forgetting `enabled: true` now produces an actionable message instead of a
+  generic one: the config error (and `microclaw start`) name the configured-but-disabled
+  channels and tell you to set `channels.<name>.enabled: true`. `microclaw doctor` now (a)
+  actually loads & validates the config (previously it only checked the file exists, so an
+  invalid config showed a misleading green), and (b) reports which channels are enabled plus
+  warns about any configured-but-disabled ones. Part of the usability/onboarding push.
 - Friendlier config parse errors — when `microclaw.config.yaml` fails to parse, the message now
   appends an actionable pointer (edit and re-run, or `microclaw setup`, plus a link to the
   annotated example config), and for an unknown field/variant (a mistyped key like `discrod`)

--- a/src/config.rs
+++ b/src/config.rs
@@ -2041,6 +2041,47 @@ impl Config {
         self.inferred_channel_enabled(&needle)
     }
 
+    /// Classify every known channel into `(enabled, configured_but_disabled)`.
+    /// A channel is "configured" when it has credentials/config present (a
+    /// `channels.<name>` block or a legacy top-level token); it is "enabled"
+    /// per [`channel_enabled`]. Used both for the no-channel config error and
+    /// for `microclaw doctor`, so the two stay consistent.
+    pub fn channel_status(&self) -> (Vec<&'static str>, Vec<&'static str>) {
+        let configured = [
+            (
+                "telegram",
+                !self.telegram_bot_token.trim().is_empty()
+                    || self.channels.contains_key("telegram"),
+            ),
+            (
+                "discord",
+                self.discord_bot_token
+                    .as_deref()
+                    .map(|v| !v.trim().is_empty())
+                    .unwrap_or(false)
+                    || self.channels.contains_key("discord"),
+            ),
+            ("slack", self.channels.contains_key("slack")),
+            ("feishu", self.channels.contains_key("feishu")),
+            ("matrix", self.channels.contains_key("matrix")),
+            ("irc", self.channels.contains_key("irc")),
+            ("web", self.web_enabled || self.channels.contains_key("web")),
+        ];
+        let mut enabled = Vec::new();
+        let mut configured_but_disabled = Vec::new();
+        for (name, is_configured) in configured {
+            if !is_configured {
+                continue;
+            }
+            if self.channel_enabled(name) {
+                enabled.push(name);
+            } else {
+                configured_but_disabled.push(name);
+            }
+        }
+        (enabled, configured_but_disabled)
+    }
+
     /// Load config from YAML file.
     pub fn load() -> Result<Self, MicroClawError> {
         let yaml_path = Self::resolve_config_path()?;
@@ -2460,39 +2501,20 @@ Use operator password + API keys for Web auth."
         }
 
         // Validate required fields
-        let configured_telegram =
-            !self.telegram_bot_token.trim().is_empty() || self.channels.contains_key("telegram");
-        let configured_discord = self
-            .discord_bot_token
-            .as_deref()
-            .map(|v| !v.trim().is_empty())
-            .unwrap_or(false)
-            || self.channels.contains_key("discord");
-        let configured_slack = self.channels.contains_key("slack");
-        let configured_feishu = self.channels.contains_key("feishu");
-        let configured_matrix = self.channels.contains_key("matrix");
-        let configured_irc = self.channels.contains_key("irc");
-        let configured_web = self.web_enabled || self.channels.contains_key("web");
-
-        let has_telegram = self.channel_enabled("telegram") && configured_telegram;
-        let has_discord = self.channel_enabled("discord") && configured_discord;
-        let has_slack = self.channel_enabled("slack") && configured_slack;
-        let has_feishu = self.channel_enabled("feishu") && configured_feishu;
-        let has_matrix = self.channel_enabled("matrix") && configured_matrix;
-        let has_irc = self.channel_enabled("irc") && configured_irc;
-        let has_web = self.channel_enabled("web") && configured_web;
-
-        if !(has_telegram
-            || has_discord
-            || has_slack
-            || has_feishu
-            || has_matrix
-            || has_irc
-            || has_web)
-        {
-            return Err(MicroClawError::Config(
-                "At least one channel must be enabled and configured (via channels.<name>.enabled or legacy channel settings)".into(),
-            ));
+        let (enabled_channels, configured_but_disabled) = self.channel_status();
+        if enabled_channels.is_empty() {
+            let hint = if configured_but_disabled.is_empty() {
+                String::new()
+            } else {
+                format!(
+                    " These channels are configured but not enabled: {}. \
+                     Set `channels.<name>.enabled: true` (or run `microclaw setup`).",
+                    configured_but_disabled.join(", ")
+                )
+            };
+            return Err(MicroClawError::Config(format!(
+                "At least one channel must be enabled and configured (via channels.<name>.enabled or legacy channel settings).{hint}"
+            )));
         }
         if self.api_key.is_empty() && !provider_allows_empty_api_key(&self.llm_provider) {
             return Err(MicroClawError::Config("api_key is required".into()));
@@ -2977,6 +2999,28 @@ mod tests {
         assert_eq!(levenshtein("kitten", "sitting"), 3);
         assert_eq!(levenshtein("discord", "discord"), 0);
         assert_eq!(levenshtein("", "abc"), 3);
+    }
+
+    #[test]
+    fn channel_status_splits_enabled_and_disabled() {
+        let cfg: Config = serde_yaml::from_str(
+            "api_key: k\nweb_enabled: false\nchannels:\n  telegram:\n    enabled: true\n  discord:\n    enabled: false\n",
+        )
+        .unwrap();
+        let (enabled, disabled) = cfg.channel_status();
+        assert_eq!(enabled, vec!["telegram"]);
+        assert_eq!(disabled, vec!["discord"]);
+    }
+
+    #[test]
+    fn no_enabled_channel_error_names_disabled_channel() {
+        let mut cfg: Config = serde_yaml::from_str(
+            "api_key: k\nweb_enabled: false\nchannels:\n  telegram:\n    enabled: false\n",
+        )
+        .unwrap();
+        let err = cfg.post_deserialize().unwrap_err().to_string();
+        assert!(err.contains("configured but not enabled"), "got: {err}");
+        assert!(err.contains("telegram"), "got: {err}");
     }
 
     #[test]

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -407,6 +407,7 @@ fn build_report() -> DoctorReport {
     );
 
     check_config(&mut report);
+    check_channels(&mut report);
     check_acp_subagent_config(&mut report);
     check_web_fetch_validation(&mut report);
     check_context_layers(&mut report);
@@ -443,13 +444,22 @@ fn build_sandbox_report() -> DoctorReport {
 
 fn check_config(report: &mut DoctorReport) {
     match Config::resolve_config_path() {
-        Ok(Some(path)) => report.push(
-            "config.file",
-            "Config file",
-            CheckStatus::Pass,
-            format!("found {}", path.display()),
-            None,
-        ),
+        Ok(Some(path)) => match Config::load() {
+            Ok(_) => report.push(
+                "config.file",
+                "Config file",
+                CheckStatus::Pass,
+                format!("found and valid: {}", path.display()),
+                None,
+            ),
+            Err(err) => report.push(
+                "config.file",
+                "Config file",
+                CheckStatus::Fail,
+                err.to_string(),
+                Some("Fix the config per the message above, or run `microclaw setup`.".to_string()),
+            ),
+        },
         Ok(None) => report.push(
             "config.file",
             "Config file",
@@ -464,6 +474,45 @@ fn check_config(report: &mut DoctorReport) {
             err.to_string(),
             Some("Fix MICROCLAW_CONFIG or create a valid config file.".to_string()),
         ),
+    }
+}
+
+fn check_channels(report: &mut DoctorReport) {
+    // A failed load (e.g. no channel enabled at all) is already reported by
+    // `check_config`; here we add detail when the config does load.
+    let config = match Config::load() {
+        Ok(cfg) => cfg,
+        Err(_) => return,
+    };
+    let (enabled, configured_but_disabled) = config.channel_status();
+    if enabled.is_empty() {
+        report.push(
+            "channels.enabled",
+            "Channels",
+            CheckStatus::Fail,
+            "no channels are enabled".to_string(),
+            Some("Enable a channel with `channels.<name>.enabled: true`, or run `microclaw setup`.".to_string()),
+        );
+    } else {
+        report.push(
+            "channels.enabled",
+            "Channels",
+            CheckStatus::Pass,
+            format!("enabled: {}", enabled.join(", ")),
+            None,
+        );
+    }
+    if !configured_but_disabled.is_empty() {
+        report.push(
+            "channels.configured_disabled",
+            "Channels configured but disabled",
+            CheckStatus::Warn,
+            format!("{} configured but not enabled", configured_but_disabled.join(", ")),
+            Some(format!(
+                "Set `channels.{}.enabled: true` to activate (or remove the unused config).",
+                configured_but_disabled[0]
+            )),
+        );
     }
 }
 


### PR DESCRIPTION
Usability push — covers the **"doctor: at least one channel enabled"** item (and fixes the underlying error message at its source).

## Problem

The most common onboarding trap: you fill in a channel's credentials but forget `enabled: true`. Today that fails with a generic *"At least one channel must be enabled and configured"* — and `microclaw doctor` didn't catch it at all, because `check_config` only verified the file *existed*.

## What

- **`Config::channel_status()`** — classifies every known channel into `(enabled, configured_but_disabled)`. The no-channel-enabled error now names the offenders:
  > At least one channel must be enabled and configured … **These channels are configured but not enabled: telegram. Set `channels.<name>.enabled: true`** (or run `microclaw setup`).

  This benefits *every* entry point (`start`, `doctor`, …) since it's at the config-load layer.
- **`microclaw doctor`**:
  - `check_config` now **loads & validates** the config (not just resolves the path), so an invalid config shows ❌ FAIL with the actionable message instead of a misleading green "found".
  - new **channels check**: ✅ reports which channels are enabled, ⚠️ warns about configured-but-disabled ones with the exact fix.

```
[❌ FAIL] Config file   Config error: At least one channel must be enabled … configured but not enabled: telegram. Set `channels.<name>.enabled: true` …
# or, when valid:
[✅ PASS] Channels                     enabled: web
[⚠️ WARN] Channels configured but disabled  discord configured but not enabled
        fix: Set `channels.discord.enabled: true` to activate (or remove the unused config).
```

## Changes

- `src/config.rs`: `channel_status()`; `post_deserialize` refactored to use it and emit the named-channel hint (behavior preserved — same enable rule). 2 new tests.
- `src/doctor.rs`: `check_config` loads+validates; new `check_channels`.
- `CHANGELOG.md`.

## Verification

- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo test --lib config::tests` (78) and `doctor` (11) — all pass.
- End-to-end: doctor FAILs naming `telegram` for a no-channel config; PASSes web + WARNs disabled discord for a valid one.

## Compatibility / rollback

The enable rule is unchanged (same channels, same logic) — only the error text is richer and doctor reports more. Clean revert.

---
https://claude.ai/code/session_0139tsJZ9v1Um6fNrP7K72MZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0139tsJZ9v1Um6fNrP7K72MZ)_