### PR TITLE
feat(channels): actionable auth-failure messages on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is loosely based on Keep a Changelog. Dates use UTC.
 
 ## Unreleased
 
+### Changed
+
+- Clearer channel auth-failure logs — when a channel can't start because its credentials are
+  rejected, Telegram/Discord/Slack/Feishu now log an actionable message ("authentication
+  failed … check the token / run `microclaw setup`") instead of a generic or silent error,
+  so a bad token isn't mistaken for the bot just going quiet. Part of the usability push.
+
 ### Added
 
 - Clearer "no channel enabled" diagnostics — the common trap of filling in a channel's

--- a/src/channels/discord.rs
+++ b/src/channels/discord.rs
@@ -876,7 +876,10 @@ pub async fn start_discord_bot(
             }
         }
         Err(e) => {
-            error!("Discord bot error: {e}");
+            error!(
+                "Discord bot failed to start: {e}. If this is an authentication error, \
+                 check `discord.bot_token` (from the Discord Developer Portal) — run `microclaw setup`."
+            );
         }
     }
 }

--- a/src/channels/feishu.rs
+++ b/src/channels/feishu.rs
@@ -2114,7 +2114,10 @@ pub async fn start_feishu_bot(app_state: Arc<AppState>, runtime: FeishuRuntimeCo
     {
         Ok(t) => t,
         Err(e) => {
-            error!("Feishu: failed to get initial token: {e}");
+            error!(
+                "Feishu channel failed to start: could not obtain a tenant token: {e}. \
+                 This is usually a bad `feishu.app_id` / `feishu.app_secret` — run `microclaw setup`."
+            );
             return;
         }
     };
@@ -2126,7 +2129,10 @@ pub async fn start_feishu_bot(app_state: Arc<AppState>, runtime: FeishuRuntimeCo
             id
         }
         Err(e) => {
-            error!("Feishu: failed to resolve bot open_id: {e}");
+            error!(
+                "Feishu: failed to resolve bot open_id: {e}. \
+                 Check the app credentials and permissions (run `microclaw setup`)."
+            );
             return;
         }
     };

--- a/src/channels/slack.rs
+++ b/src/channels/slack.rs
@@ -906,7 +906,10 @@ pub async fn start_slack_bot(app_state: Arc<AppState>, runtime: SlackRuntimeCont
             id
         }
         Err(e) => {
-            error!("Failed to resolve Slack bot user ID: {e}");
+            error!(
+                "Slack channel failed to start: {e}. If this is an authentication error, \
+                 check `slack.bot_token` and `slack.app_token` — run `microclaw setup`."
+            );
             return;
         }
     };

--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -493,13 +493,15 @@ pub async fn start_telegram_bot(
         Ok(()) => {}
         Err(teloxide::RequestError::Api(teloxide::ApiError::InvalidToken)) => {
             warn!(
-                "Telegram channel '{}' disabled: invalid bot token. Update telegram_bot_token and restart.",
+                "Telegram channel '{}' disabled: authentication failed (invalid bot token). \
+                 Update the token (from @BotFather) and restart, or run `microclaw setup`.",
                 channel_name
             );
         }
         Err(err) => {
             warn!(
-                "Telegram channel '{}' stopped and was disabled due to startup error: {:?}",
+                "Telegram channel '{}' stopped due to a startup error: {:?}. \
+                 If this is an authentication error, check the bot token (run `microclaw setup`).",
                 channel_name, err
             );
         }


### PR DESCRIPTION
Usability push — the **"runtime credential-failure friendly message"** item.

## Problem

When a channel can't start because its token/credentials are rejected, the bot effectively went quiet with only a generic or low-signal log: Discord said `Discord bot error: {e}`, Slack `Failed to resolve Slack bot user ID: {e}`, Feishu `failed to get initial token: {e}`, and Telegram named the field but no fix path. A self-hoster can't tell "bad token" from "bot crashed".

## What

Each adapter now logs an **actionable** message on auth/startup failure, naming the specific credential and pointing at `microclaw setup`:

- **Telegram** — invalid-token and generic startup errors mention the @BotFather token + `microclaw setup`.
- **Discord** — startup failure: "If this is an authentication error, check `discord.bot_token` … run `microclaw setup`."
- **Slack** — bot-user resolution failure: check `slack.bot_token` / `slack.app_token`.
- **Feishu** — token + open_id failures: check `feishu.app_id` / `feishu.app_secret`.

## Changes

- `src/channels/{telegram,discord,slack,feishu}.rs` — log-message text only. No control-flow or logic change (channels still fail/disable exactly as before; only the message is clearer).
- `CHANGELOG.md`.

## Verification

- `cargo build` + `cargo clippy --all-targets -- -D warnings` — clean.
- Pure string changes in existing error/warn arms; no behavioral surface to unit-test.

## Compatibility / rollback

Log text only. Clean revert.

---
https://claude.ai/code/session_0139tsJZ9v1Um6fNrP7K72MZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0139tsJZ9v1Um6fNrP7K72MZ)_