### PR TITLE
feat(doctor): live LLM credential check via `doctor --online`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ The format is loosely based on Keep a Changelog. Dates use UTC.
 
 ### Added
 
+- `microclaw doctor --online` — verifies the LLM credentials by sending a minimal "hi" request
+  to the configured provider (reusing the setup wizard's probe), so a bad API key or model is
+  caught at preflight instead of surfacing as a confusing failure on the first chat. Rejected
+  credentials are a ❌ FAIL with a fix hint; a network/transient failure is a ⚠️ WARN (so an
+  offline run isn't falsely red); `openai-codex` is skipped (external auth). Without `--online`,
+  `doctor` stays hermetic and notes that credentials weren't verified. Part of the usability push.
 - Clearer "no channel enabled" diagnostics — the common trap of filling in a channel's
   credentials but forgetting `enabled: true` now produces an actionable message instead of a
   generic one: the config error (and `microclaw start`) name the configured-but-disabled

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -112,6 +112,9 @@ struct DoctorCli {
     json: bool,
     #[arg(long, default_value_t = false)]
     apply_config_migrations: bool,
+    /// Send a live test request to the LLM provider to verify the API key/model.
+    #[arg(long, default_value_t = false)]
+    online: bool,
 }
 
 #[derive(Debug, Subcommand)]
@@ -163,11 +166,16 @@ pub fn run_cli(args: &[String]) -> anyhow::Result<()> {
         }
     }
 
-    let report = if sandbox_only {
+    let mut report = if sandbox_only {
         build_sandbox_report()
     } else {
         build_report()
     };
+    if !sandbox_only {
+        // Network probe lives outside `build_report` so the offline report stays
+        // pure (and hermetic for tests).
+        check_llm_credentials(&mut report, cli.online);
+    }
 
     if json_output {
         println!("{}", serde_json::to_string_pretty(&report)?);
@@ -514,6 +522,108 @@ fn check_channels(report: &mut DoctorReport) {
             )),
         );
     }
+}
+
+/// Verify the configured LLM credentials with a live "hi" request (only when
+/// `online` is set, since `doctor` is otherwise hermetic). Reuses the same probe
+/// as the setup wizard. Runs on a dedicated thread because the probe uses
+/// blocking HTTP and `doctor` runs inside an async runtime.
+fn check_llm_credentials(report: &mut DoctorReport, online: bool) {
+    let config = match Config::load() {
+        Ok(cfg) => cfg,
+        Err(_) => return, // load failure already reported by check_config
+    };
+    let provider = config.llm_provider.clone();
+
+    if crate::codex_auth::is_openai_codex_provider(&provider) {
+        report.push(
+            "llm.credentials",
+            "LLM credentials",
+            CheckStatus::Miss,
+            "openai-codex uses external auth (~/.codex); not probed".to_string(),
+            None,
+        );
+        return;
+    }
+
+    if !online {
+        report.push(
+            "llm.credentials",
+            "LLM credentials",
+            CheckStatus::Miss,
+            "not verified (offline)".to_string(),
+            Some("Run `microclaw doctor --online` to send a test request to the provider.".to_string()),
+        );
+        return;
+    }
+
+    let api_key = config.api_key.clone();
+    let base_url = config.llm_base_url.clone().unwrap_or_default();
+    let model = config.model.clone();
+    let user_agent = config.llm_user_agent.clone();
+
+    // Blocking probe on its own thread (doctor runs under Tokio).
+    let probe = std::thread::spawn(move || {
+        crate::setup::validate_llm_credentials(&provider, &api_key, &base_url, &user_agent, &model, None)
+    })
+    .join();
+
+    match probe {
+        Ok(Ok(msg)) => report.push(
+            "llm.credentials",
+            "LLM credentials",
+            CheckStatus::Pass,
+            msg,
+            None,
+        ),
+        Ok(Err(err)) => {
+            let detail = err.to_string();
+            if looks_like_auth_error(&detail) {
+                report.push(
+                    "llm.credentials",
+                    "LLM credentials",
+                    CheckStatus::Fail,
+                    detail,
+                    Some("Check your `api_key` and `model` — run `microclaw setup`.".to_string()),
+                );
+            } else {
+                report.push(
+                    "llm.credentials",
+                    "LLM credentials",
+                    CheckStatus::Warn,
+                    format!("could not verify: {detail}"),
+                    Some("Provider unreachable or a transient error; check `llm_base_url`/network and retry.".to_string()),
+                );
+            }
+        }
+        Err(_) => report.push(
+            "llm.credentials",
+            "LLM credentials",
+            CheckStatus::Warn,
+            "credential probe thread panicked".to_string(),
+            None,
+        ),
+    }
+}
+
+/// Heuristic: does this validation error look like rejected credentials (vs a
+/// network/transient failure)?
+fn looks_like_auth_error(detail: &str) -> bool {
+    let l = detail.to_lowercase();
+    [
+        "401",
+        "403",
+        "unauthorized",
+        "invalid x-api-key",
+        "invalid api key",
+        "incorrect api key",
+        "authentication",
+        "api key",
+        "api-key",
+        "permission denied",
+    ]
+    .iter()
+    .any(|needle| l.contains(needle))
 }
 
 fn check_web_fetch_validation(report: &mut DoctorReport) {
@@ -1657,6 +1767,17 @@ mod tests {
 
     fn env_lock() -> std::sync::MutexGuard<'static, ()> {
         crate::test_support::env_lock()
+    }
+
+    #[test]
+    fn auth_error_classification() {
+        // Provider rejections → auth (Fail).
+        assert!(looks_like_auth_error("LLM validation failed: invalid x-api-key"));
+        assert!(looks_like_auth_error("HTTP 401 Unauthorized"));
+        assert!(looks_like_auth_error("Incorrect API key provided"));
+        // Network/transient → not auth (Warn).
+        assert!(!looks_like_auth_error("error sending request: dns error"));
+        assert!(!looks_like_auth_error("operation timed out"));
     }
 
     #[test]

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -5921,15 +5921,14 @@ fn perform_online_validation(
     model: &str,
     codex_account_id: Option<&str>,
 ) -> Result<Vec<String>, MicroClawError> {
-    const VALIDATION_MAX_OUTPUT_TOKENS: u32 = 64;
     let mut checks = Vec::new();
-    let client = reqwest::blocking::Client::builder()
-        .timeout(Duration::from_secs(30))
-        .user_agent(llm_user_agent(configured_user_agent))
-        .build()?;
 
     // --- Telegram validation (optional) ---
     if telegram_enabled {
+        let client = reqwest::blocking::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .user_agent(llm_user_agent(configured_user_agent))
+            .build()?;
         let tg_resp: serde_json::Value = client
             .get(format!("https://api.telegram.org/bot{tg_token}/getMe"))
             .send()?
@@ -5961,6 +5960,37 @@ fn perform_online_validation(
     }
 
     // --- LLM validation: send a minimal "hi" message ---
+    checks.push(validate_llm_credentials(
+        provider,
+        api_key,
+        base_url,
+        configured_user_agent,
+        model,
+        codex_account_id,
+    )?);
+
+    Ok(checks)
+}
+
+/// Send a minimal "hi" message to the configured LLM provider to verify the
+/// API key/model work. Returns a human-friendly "LLM OK (...)" string on
+/// success, or a `MicroClawError::Config` describing the failure. Shared by the
+/// setup wizard and `microclaw doctor`. Synchronous (blocking HTTP), so callers
+/// inside an async runtime must run it on a dedicated thread.
+pub(crate) fn validate_llm_credentials(
+    provider: &str,
+    api_key: &str,
+    base_url: &str,
+    configured_user_agent: &str,
+    model: &str,
+    codex_account_id: Option<&str>,
+) -> Result<String, MicroClawError> {
+    const VALIDATION_MAX_OUTPUT_TOKENS: u32 = 64;
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .user_agent(llm_user_agent(configured_user_agent))
+        .build()?;
+
     let preset = find_provider_preset(provider);
     let protocol = provider_protocol(provider);
     let model = if model.is_empty() {
@@ -6006,7 +6036,7 @@ fn perform_online_validation(
                 "LLM validation failed: {detail}"
             )));
         }
-        checks.push(format!("LLM OK (anthropic, model={model})"));
+        Ok(format!("LLM OK (anthropic, model={model})"))
     } else {
         let base = resolve_openai_compat_validation_base(provider, base_url, preset);
         let resp = if is_openai_codex_provider(provider) {
@@ -6058,20 +6088,17 @@ fn perform_online_validation(
         if !status.is_success() {
             let text = resp.text().unwrap_or_default();
             if is_validation_output_capped_error(&text) {
-                checks.push(format!(
+                return Ok(format!(
                     "LLM OK (openai-compatible, model={model}; probe output capped)"
                 ));
-                return Ok(checks);
             }
             let detail = extract_openai_error_detail(status, &text);
             return Err(MicroClawError::Config(format!(
                 "LLM validation failed: {detail}"
             )));
         }
-        checks.push(format!("LLM OK (openai-compatible, model={model})"));
+        Ok(format!("LLM OK (openai-compatible, model={model})"))
     }
-
-    Ok(checks)
 }
 
 fn push_telegram_disabled_status(checks: &mut Vec<String>, include_telegram_status: bool) {


### PR DESCRIPTION
Usability push — the **"doctor validates LLM credentials"** item.

## Problem

A bad API key or model name only surfaced as a confusing failure on the *first chat*. `doctor` had no way to catch it.

## What

`microclaw doctor --online` sends a minimal "hi" request to the configured provider at preflight, reusing the setup wizard's proven probe:

```
# offline (default — hermetic):
[🌿 MISS] LLM credentials   not verified (offline)
        fix: Run `microclaw doctor --online` to send a test request to the provider.

# --online with a bad key:
[❌ FAIL] LLM credentials   Config error: LLM validation failed: invalid x-api-key
        fix: Check your `api_key` and `model` — run `microclaw setup`.
```

- **Rejected credentials → ❌ FAIL** (exit 2) with a fix hint.
- **Network/transient error → ⚠️ WARN** (so an offline/air-gapped run isn't falsely red).
- **`openai-codex` → skipped** (external `~/.codex` auth, no api_key to probe).
- Without `--online`, `doctor` stays **hermetic** and notes credentials weren't verified.

## Design

- Reuses the wizard's logic instead of duplicating it: extracted the LLM half of `perform_online_validation` into a shared `pub(crate) validate_llm_credentials(...)` (the wizard now calls it too — same behavior).
- `doctor` runs under Tokio but the probe uses blocking HTTP, so it runs on a **dedicated `std::thread`** (avoids a nested-runtime panic). Default opt-in keeps `doctor` fast/hermetic; `--online` is the explicit network check.

## Changes

- `src/setup.rs`: extract `validate_llm_credentials`; `perform_online_validation` calls it (Telegram client scoped to its branch).
- `src/doctor.rs`: `--online` flag; `check_llm_credentials` + `looks_like_auth_error`. The probe lives in `run_cli`, so `build_report()` stays arg-free (tests untouched).
- `CHANGELOG.md`.

## Verification

- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo test --lib doctor` (12, incl. new `auth_error_classification`) and `setup` (87) — all pass.
- End-to-end: offline note shown; `--online` with a bogus Anthropic key → FAIL `invalid x-api-key`.

## Compatibility / rollback

The wizard probe is unchanged (refactor only). Default `doctor` makes no new network calls (`--online` is opt-in). Clean revert.

---
https://claude.ai/code/session_0139tsJZ9v1Um6fNrP7K72MZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0139tsJZ9v1Um6fNrP7K72MZ)_