### PR TITLE
feat(setup): refuse to save a config with no channel enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ The format is loosely based on Keep a Changelog. Dates use UTC.
 
 ### Added
 
+- Setup wizard now refuses to save a config with no channel enabled — the source-side fix for
+  "configured a channel but forgot `enabled: true`". Clearing all channels blocks save with a
+  clear instruction instead of producing a config that fails to start. (The field defaults to
+  `web`, so a normal setup is unaffected.) Part of the usability push.
 - `microclaw doctor --online` — verifies the LLM credentials by sending a minimal "hi" request
   to the configured provider (reusing the setup wizard's probe), so a bad API key or model is
   caught at preflight instead of surfacing as a confusing failure on the first chat. Rejected

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -4385,6 +4385,15 @@ impl SetupApp {
     }
 
     fn validate_local(&self) -> Result<(), MicroClawError> {
+        // A config with no enabled channel can't start, so refuse to save one —
+        // this is the source-side fix for "configured a channel but forgot to
+        // enable it". (The field defaults to `web`, so a normal setup passes.)
+        if self.enabled_channels().is_empty() {
+            return Err(MicroClawError::Config(
+                "Enable at least one channel: open the 'Enabled channels' field and select one (web, telegram, discord, ...).".into(),
+            ));
+        }
+
         for field in &self.fields {
             if self.is_field_required(field) && field.value.trim().is_empty() {
                 return Err(MicroClawError::Config(format!("{} is required", field.key)));
@@ -10907,6 +10916,19 @@ sandbox:
         assert_eq!(body.get("max_tokens"), None);
         assert_eq!(body["max_completion_tokens"], 1);
         assert!(!switch_to_max_completion_tokens(&mut body));
+    }
+
+    #[test]
+    fn validate_local_requires_an_enabled_channel() {
+        let mut app = SetupApp::new();
+        // Fresh app defaults to `web` enabled, so the channel gate passes.
+        assert!(!app.enabled_channels().is_empty());
+        // Clearing all channels must block save with a clear message.
+        if let Some(f) = app.fields.iter_mut().find(|f| f.key == "ENABLED_CHANNELS") {
+            f.value = String::new();
+        }
+        let err = app.validate_local().unwrap_err().to_string();
+        assert!(err.contains("at least one channel"), "got: {err}");
     }
 
     #[test]


### PR DESCRIPTION
Usability push — the final item, the **"setup wizard: force enable a channel"** source fix.

## Problem

`ENABLED_CHANNELS` is `required: false`, so a user can clear every channel and finish the wizard, producing a config that fails to start with "at least one channel must be enabled". That's the source of the "configured a channel but forgot `enabled: true`" trap.

## What

The wizard's local validation (`validate_local`, which gates both save paths) now refuses to save when no channel is enabled:

> Enable at least one channel: open the 'Enabled channels' field and select one (web, telegram, discord, ...).

The `ENABLED_CHANNELS` field defaults to `web`, so a normal setup is unaffected — this only triggers if the user explicitly clears everything (which would otherwise produce an unstartable config).

## Changes

- `src/setup.rs`: one gate at the top of `validate_local`, reusing the existing `enabled_channels()`. Unit test `validate_local_requires_an_enabled_channel`.
- `CHANGELOG.md`.

## Verification

- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo test --lib setup` — 88 pass (incl. the new test); existing `..._without_enabled_channels` save test still green (configured-but-disabled channels remain a supported state, as long as ≥1 is enabled).

## Compatibility / rollback

Only adds a pre-save check; default setup (web enabled) is unchanged. Clean revert.

---

This completes the 4-item usability/onboarding batch: doctor channel diagnostics (#422), channel auth-failure messages (#423), `doctor --online` credential probe (#424), and this wizard gate.

https://claude.ai/code/session_0139tsJZ9v1Um6fNrP7K72MZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0139tsJZ9v1Um6fNrP7K72MZ)_