### PR TITLE
feat(doctor): check data/working dir writability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ The format is loosely based on Keep a Changelog. Dates use UTC.
 
 ### Added
 
+- `microclaw doctor` now checks that the data and working directories can be created and
+  written to — the most common "won't start" cause (read-only path, wrong permissions, a
+  typo'd `data_dir`). Reports each as ✅ writable or ❌ with the failure reason and a fix hint.
+  Part of the usability push.
 - Setup wizard now refuses to save a config with no channel enabled — the source-side fix for
   "configured a channel but forgot `enabled: true`". Clearing all channels blocks save with a
   clear instruction instead of producing a config that fails to start. (The field defaults to

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -416,6 +416,7 @@ fn build_report() -> DoctorReport {
 
     check_config(&mut report);
     check_channels(&mut report);
+    check_data_dirs(&mut report);
     check_acp_subagent_config(&mut report);
     check_web_fetch_validation(&mut report);
     check_context_layers(&mut report);
@@ -522,6 +523,49 @@ fn check_channels(report: &mut DoctorReport) {
             )),
         );
     }
+}
+
+/// Verify the data and working directories can be created and written to — the
+/// most common "it just won't start" cause (read-only path, wrong permissions,
+/// a typo'd `data_dir`). The DB, runtime state, and skills all live under these.
+fn check_data_dirs(report: &mut DoctorReport) {
+    let config = match Config::load() {
+        Ok(cfg) => cfg,
+        Err(_) => return,
+    };
+    for (id, label, raw) in [
+        ("storage.data_dir", "Data dir writable", config.runtime_data_dir()),
+        ("storage.working_dir", "Working dir writable", config.working_dir.clone()),
+    ] {
+        let path = PathBuf::from(shellexpand::tilde(&raw).as_ref());
+        match check_dir_writable(&path) {
+            Ok(()) => report.push(
+                id,
+                label,
+                CheckStatus::Pass,
+                format!("writable: {}", path.display()),
+                None,
+            ),
+            Err(err) => report.push(
+                id,
+                label,
+                CheckStatus::Fail,
+                err,
+                Some("Check the path's permissions and free space, or point `data_dir`/`working_dir` at a writable location.".to_string()),
+            ),
+        }
+    }
+}
+
+/// Create `dir` if needed and confirm a file can be written there, cleaning up
+/// the probe file. Returns a human-readable reason on failure.
+fn check_dir_writable(dir: &std::path::Path) -> Result<(), String> {
+    std::fs::create_dir_all(dir)
+        .map_err(|e| format!("cannot create {}: {e}", dir.display()))?;
+    let probe = dir.join(format!(".microclaw-doctor-{}.tmp", std::process::id()));
+    std::fs::write(&probe, b"ok").map_err(|e| format!("cannot write to {}: {e}", dir.display()))?;
+    let _ = std::fs::remove_file(&probe);
+    Ok(())
 }
 
 /// Verify the configured LLM credentials with a live "hi" request (only when
@@ -1767,6 +1811,25 @@ mod tests {
 
     fn env_lock() -> std::sync::MutexGuard<'static, ()> {
         crate::test_support::env_lock()
+    }
+
+    #[test]
+    fn dir_writable_ok_and_failure() {
+        let base = std::env::temp_dir().join(format!(
+            "mc_doctor_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        // Fresh nested path is created and written to.
+        assert!(check_dir_writable(&base.join("sub")).is_ok());
+        // A path *under a regular file* can't be made into a directory.
+        let file = base.join("afile");
+        std::fs::write(&file, b"x").unwrap();
+        assert!(check_dir_writable(&file.join("nope")).is_err());
+        let _ = std::fs::remove_dir_all(&base);
     }
 
     #[test]


### PR DESCRIPTION
Usability push — the **"doctor: disk/writability checks"** item.

## What

A read-only path, wrong permissions, or a typo'd `data_dir` is a common "won't start" cause that previously surfaced only as an opaque DB/runtime-state error. `microclaw doctor` now write-probes the directories it depends on:

```
[✅ PASS] Data dir writable      writable: ~/.microclaw/runtime
[✅ PASS] Working dir writable   writable: ~/.microclaw/working_dir
# or, on failure:
[❌ FAIL] Data dir writable      cannot write to /mnt/ro/runtime: Read-only file system
        fix: Check the path's permissions and free space, or point `data_dir`/`working_dir` at a writable location.
```

`check_dir_writable` creates the dir (`create_dir_all`), writes + deletes a probe file, and returns a human-readable reason on failure. (No disk-space crate is available in-tree, so this covers the high-value writability/permissions case rather than raw free-space.)

## Changes

- `src/doctor.rs`: `check_data_dirs` (registered in `build_report`) + `check_dir_writable`. Uses `shellexpand` (already a dep) to expand `~`. Unit test covers the ok + failure paths.
- `CHANGELOG.md`.

## Verification

- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo test --lib doctor` — 13 pass (incl. new `dir_writable_ok_and_failure`).
- End-to-end: doctor reports both dirs writable for a valid config.

## Compatibility / rollback

Additive read-only check (the probe file is created and removed; the dirs would be created by the bot anyway). Clean revert.

---
https://claude.ai/code/session_0139tsJZ9v1Um6fNrP7K72MZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0139tsJZ9v1Um6fNrP7K72MZ)_