### PR TITLE
feat(cli): add Examples section to --help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ The format is loosely based on Keep a Changelog. Dates use UTC.
 
 ### Added
 
+- `microclaw --help` now ends with an **Examples** section (setup, doctor, `doctor --online`,
+  start, `skill audit`, `audit verify`, `eval`) and a pointer to per-command `--help`, so the
+  common workflows are discoverable without reading docs. Part of the usability push.
 - `microclaw doctor` now checks that the data and working directories can be created and
   written to — the most common "won't start" cause (read-only path, wrong permissions, a
   typo'd `data_dir`). Reports each as ✅ writable or ❌ with the failure reason and a fix hint.

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,11 +27,26 @@ const LONG_ABOUT: &str = concat!(
     "Once running, send \x1b[1m/help\x1b[22m in any chat to list the in-chat commands.",
 );
 
+const EXAMPLES: &str = concat!(
+    "\x1b[1mExamples:\x1b[22m\n",
+    "  microclaw setup                 Create or edit microclaw.config.yaml\n",
+    "  microclaw doctor                Run preflight checks\n",
+    "  microclaw doctor --online       Also test your API key/model with a live request\n",
+    "  microclaw start                 Start the bot on the enabled channels\n",
+    "  microclaw skill audit           Audit local skills (duplicates, stale, thin)\n",
+    "  microclaw audit verify          Verify the tamper-evident audit log\n",
+    "  microclaw eval <file|dir>       Evaluate recorded session trajectories\n",
+    "\n",
+    "Run 'microclaw <command> --help' for command-specific options.",
+);
+
 #[derive(Debug, Parser)]
 #[command(
     name = "microclaw",
     version = VERSION,
-    about = LONG_ABOUT
+    about = LONG_ABOUT,
+    after_help = EXAMPLES,
+    after_long_help = EXAMPLES,
 )]
 struct Cli {
     /// Explicit config file path (absolute or relative)


### PR DESCRIPTION
Usability push — the **"CLI examples / clearer --help"** item.

## What

`microclaw --help` listed the commands but gave no usage examples. It now ends with an **Examples** block and a pointer to per-command help:

```
Examples:
  microclaw setup                 Create or edit microclaw.config.yaml
  microclaw doctor                Run preflight checks
  microclaw doctor --online       Also test your API key/model with a live request
  microclaw start                 Start the bot on the enabled channels
  microclaw skill audit           Audit local skills (duplicates, stale, thin)
  microclaw audit verify          Verify the tamper-evident audit log
  microclaw eval <file|dir>       Evaluate recorded session trajectories

Run 'microclaw <command> --help' for command-specific options.
```

## Changes

- `src/main.rs`: an `EXAMPLES` const wired as clap `after_help` / `after_long_help`. Help text only — no parsing or behavior change.
- `CHANGELOG.md`.

## Verification

- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo test --bin microclaw` — 10 pass (arg parsing unaffected).
- `microclaw --help` renders the Examples section.

## Compatibility / rollback

Help text only. Clean revert.

---
https://claude.ai/code/session_0139tsJZ9v1Um6fNrP7K72MZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0139tsJZ9v1Um6fNrP7K72MZ)_