### PR TITLE
feat(setup): label optional fields, not just required ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ The format is loosely based on Keep a Changelog. Dates use UTC.
 
 ### Added
 
+- Setup wizard now labels every field `[required]` or `[optional]` (previously only required
+  fields were marked, leaving "unmarked" ambiguous), so it's obvious at a glance what must be
+  filled before saving. Part of the usability push.
 - `microclaw --help` now ends with an **Examples** section (setup, doctor, `doctor --online`,
   start, `skill audit`, `audit verify`, `eval`) and a pointer to per-command `--help`, so the
   common workflows are discoverable without reading docs. Part of the usability push.

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -7432,10 +7432,12 @@ fn draw_ui(frame: &mut ratatui::Frame<'_>, app: &SetupApp) {
 
         let selected = i == app.selected;
         let is_required = app.is_field_required(f);
+        // Mark every field so "unmarked" is never ambiguous: required fields
+        // must be filled before saving; optional ones can be left blank.
         let label = if is_required {
             format!("{}  [required]", f.label)
         } else {
-            f.label.to_string()
+            format!("{}  [optional]", f.label)
         };
         let value = if f.key == "LLM_PROVIDER" {
             provider_display(&f.value)


### PR DESCRIPTION
Usability push — the **"setup `[required]/[optional]` field labels"** item.

## What

The wizard already marked required fields with `[required]`, but left optional fields **unmarked** — so "unmarked" was ambiguous (genuinely optional, or a missing marker?). Now every field gets a marker:

```
▶ LLM API key  [required]: sk-ant-…
  Timezone     [optional]: UTC
```

The per-field detail panel already showed "Required: yes/no"; this makes the same information obvious at a glance in the field list.

## Changes

- `src/setup.rs`: one render branch — optional fields now get `  [optional]`, symmetric with the existing `  [required]`. Render-only; no behavior/validation change.
- `CHANGELOG.md`.

## Verification

- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo test --lib setup` — 88 pass.

## Compatibility / rollback

Cosmetic label in the TUI field list. Clean revert.

---
This wraps the second usability polish batch: doctor dir-writability (#426), `--help` examples (#427), and these field labels.

https://claude.ai/code/session_0139tsJZ9v1Um6fNrP7K72MZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0139tsJZ9v1Um6fNrP7K72MZ)_