### PR TITLE
feat(cli): post-setup next steps + per-subcommand --help examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ The format is loosely based on Keep a Changelog. Dates use UTC.
 
 ### Added
 
+- More guidance in the CLI: after `microclaw setup` succeeds it now prints the next steps
+  (`microclaw doctor` → `microclaw start`, with a note about `doctor --online`); and
+  `microclaw eval --help`, `microclaw audit --help`, and `microclaw doctor --help` each end
+  with an Examples section. (`doctor --help` now routes to the doctor parser so its options and
+  examples actually show.) Part of the usability push.
 - Setup wizard now labels every field `[required]` or `[optional]` (previously only required
   fields were marked, leaving "unmarked" ambiguous), so it's obvious at a glance what must be
   filled before saving. Part of the usability push.

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -103,7 +103,12 @@ impl DoctorReport {
 #[command(
     name = "microclaw doctor",
     about = "Preflight diagnostics",
-    long_about = "Checks PATH, shell/runtime dependencies, browser automation prerequisites, MCP command dependencies, and sandbox readiness."
+    long_about = "Checks PATH, shell/runtime dependencies, browser automation prerequisites, MCP command dependencies, and sandbox readiness.",
+    after_help = "\x1b[1mExamples:\x1b[22m\n  \
+        microclaw doctor             Run the offline preflight checks\n  \
+        microclaw doctor --online    …and verify the API key/model with a live request\n  \
+        microclaw doctor sandbox     Check container runtime + image readiness\n  \
+        microclaw doctor --json      Machine-readable report"
 )]
 struct DoctorCli {
     #[command(subcommand)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,9 @@ enum MainCommand {
     /// Full-screen setup wizard (or `setup --enable-sandbox`)
     Setup(SetupCommand),
     /// Preflight diagnostics
+    #[command(disable_help_flag = true)]
     Doctor {
+        /// Use `microclaw doctor --help` for options and examples.
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
@@ -101,6 +103,10 @@ enum MainCommand {
 }
 
 #[derive(Debug, Args)]
+#[command(after_help = "\x1b[1mExamples:\x1b[22m\n  \
+    microclaw eval session.json                 Check one recorded session\n  \
+    microclaw eval docs/test/eval-fixtures      Check every fixture in a directory\n  \
+    microclaw eval fixtures --strict-tool-errors --json")]
 struct EvalCommand {
     /// Path to a session fixture (.json) or a directory of fixtures
     path: String,
@@ -122,6 +128,10 @@ struct EvalCommand {
 }
 
 #[derive(Debug, Args)]
+#[command(after_help = "\x1b[1mExamples:\x1b[22m\n  \
+    microclaw audit verify                 Check the audit log hasn't been tampered with\n  \
+    microclaw audit list --kind auth       Show recent auth events\n  \
+    microclaw audit list --limit 100")]
 struct AuditCommand {
     #[command(subcommand)]
     action: AuditAction,
@@ -701,6 +711,11 @@ async fn main() -> anyhow::Result<()> {
                 let saved = setup::run_setup_wizard()?;
                 if saved {
                     println!("Setup saved to microclaw.config.yaml");
+                    println!();
+                    println!("Next steps:");
+                    println!("  1) microclaw doctor          # verify your setup");
+                    println!("     microclaw doctor --online # …and test the API key/model with a live request");
+                    println!("  2) microclaw start           # start the bot on the enabled channels");
                 } else {
                     println!("Setup canceled");
                 }


### PR DESCRIPTION
Usability push — **post-setup guidance** + **per-subcommand `--help` examples**.

## What

**1. Next steps after setup.** `microclaw setup` previously just said "Setup saved". Now it guides the user onward:

```
Setup saved to microclaw.config.yaml

Next steps:
  1) microclaw doctor          # verify your setup
     microclaw doctor --online # …and test the API key/model with a live request
  2) microclaw start           # start the bot on the enabled channels
```

**2. Per-subcommand examples.** `eval`, `audit`, and `doctor` `--help` now each end with an Examples section, e.g.:

```
$ microclaw audit --help
…
Examples:
  microclaw audit verify                 Check the audit log hasn't been tampered with
  microclaw audit list --kind auth       Show recent auth events
  microclaw audit list --limit 100
```

`doctor` is a `trailing_var_arg` passthrough, so the outer parser used to intercept `--help` and show a bare arg list. Adding `disable_help_flag` to the `Doctor` variant lets `--help` reach the doctor parser, so its real options + examples render (verified `doctor`, `doctor sandbox`, `doctor --online` still run).

## Changes

- `src/main.rs`: post-setup next-steps print; `after_help` on `EvalCommand` and `AuditCommand`; `disable_help_flag` on the `Doctor` variant.
- `src/doctor.rs`: `after_help` examples on `DoctorCli`.
- `CHANGELOG.md`.

## Verification

- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo test --bin microclaw` — 10 pass.
- `eval`/`audit`/`doctor` `--help` render examples; `doctor` and `doctor sandbox` still execute normally.

## Compatibility / rollback

Help/CLI-output text and a clap flag tweak only; no behavior change to any command's execution. Clean revert.

---
https://claude.ai/code/session_0139tsJZ9v1Um6fNrP7K72MZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0139tsJZ9v1Um6fNrP7K72MZ)_