### PR TITLE
Surface clawhub install warnings + guard eval negative fixtures

### DIFF
--- a/crates/microclaw-clawhub/src/install.rs
+++ b/crates/microclaw-clawhub/src/install.rs
@@ -18,21 +18,8 @@ pub struct InstallResult {
     pub success: bool,
     pub message: String,
     pub requires_restart: bool,
-}
-
-/// Gate check warning for user display
-pub struct GateWarning {
-    pub missing_bins: Vec<String>,
-    pub missing_envs: Vec<String>,
-    pub wrong_os: bool,
-}
-
-/// Security warning for user display
-pub struct SecurityWarning {
-    pub report_count: i32,
-    pub pending_scan: bool,
-    pub status: String,
-    pub url: String,
+    /// Non-fatal warnings surfaced to the user (unmet gates, security flags).
+    pub warnings: Vec<String>,
 }
 
 /// Main install function
@@ -59,6 +46,8 @@ pub async fn install_skill(
         target_version.to_string()
     };
 
+    let mut warnings: Vec<String> = Vec::new();
+
     // 3. Gate checks (unless skipped)
     if !options.skip_gates {
         let req = &meta
@@ -78,16 +67,37 @@ pub async fn install_skill(
             .as_ref()
             .map(|o| o.os.clone())
             .unwrap_or_default();
-        let _gate_result = check_requirements(req, &os_list);
-
-        // TODO: Return warning info if gates fail
+        let gate_result = check_requirements(req, &os_list);
+        if !gate_result.missing_bins.is_empty() {
+            warnings.push(format!(
+                "Missing required command(s): {}",
+                gate_result.missing_bins.join(", ")
+            ));
+        }
+        if !gate_result.missing_envs.is_empty() {
+            warnings.push(format!(
+                "Missing required environment variable(s): {}",
+                gate_result.missing_envs.join(", ")
+            ));
+        }
+        if gate_result.wrong_os {
+            warnings.push("Skill declares it does not support this platform".to_string());
+        }
     }
 
     // 4. Security check
     if !options.skip_security {
         if let Some(vt) = &meta.virustotal {
-            if vt.report_count >= 3 || vt.pending_scan {
-                // TODO: Return warning
+            if vt.report_count >= 3 {
+                warnings.push(format!(
+                    "VirusTotal flagged this skill: {} ({} report(s)) — review before trusting it",
+                    vt.status, vt.report_count
+                ));
+            } else if vt.pending_scan {
+                warnings.push(
+                    "VirusTotal scan is still pending — this skill has not been fully scanned"
+                        .to_string(),
+                );
             }
         }
     }
@@ -105,6 +115,7 @@ pub async fn install_skill(
                 slug
             ),
             requires_restart: false,
+            warnings,
         });
     }
     if skill_path.exists() && !options.force {
@@ -149,6 +160,7 @@ pub async fn install_skill(
         success: true,
         message: format!("Installed {} v{}", slug, actual_version),
         requires_restart: true,
+        warnings,
     })
 }
 

--- a/src/clawhub/cli.rs
+++ b/src/clawhub/cli.rs
@@ -103,6 +103,9 @@ pub async fn handle_skill_cli(args: &[String], config: &Config) -> Result<(), Mi
             match result {
                 Ok(result) => {
                     println!("{}", result.message);
+                    for w in &result.warnings {
+                        println!("  ⚠ {}", w);
+                    }
                     if result.requires_restart {
                         println!("Restart MicroClaw or run /reload-skills to activate.");
                     }

--- a/src/clawhub/tools.rs
+++ b/src/clawhub/tools.rs
@@ -175,6 +175,9 @@ impl Tool for ClawHubInstallTool {
             {
                 Ok(result) => {
                     let mut msg = result.message;
+                    for w in &result.warnings {
+                        msg.push_str(&format!("\n⚠ {}", w));
+                    }
                     if !result.success {
                         return ToolResult::error(msg);
                     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2113,6 +2113,9 @@ impl Config {
                             path_str
                         );
                     }
+                    for w in unknown_top_level_key_warnings(map) {
+                        warn!("{w} (in {path_str})");
+                    }
                 }
             }
             let mut config: Config = serde_yaml::from_str(&content)
@@ -2891,6 +2894,58 @@ fn friendly_yaml_error(path_str: &str, err: &serde_yaml::Error) -> String {
          Edit the config and re-run, or run `microclaw setup`.\n  \
          Reference: https://github.com/microclaw/microclaw/blob/main/microclaw.config.example.yaml"
     )
+}
+
+/// Build the set of accepted top-level config keys by serializing a baseline
+/// `Config` (so it stays in sync with the struct, including the flattened
+/// `clawhub_*` keys), plus the few fields excluded from serialization and the
+/// deprecated aliases handled elsewhere. Returns `None` if the baseline can't
+/// be derived, so callers skip the check rather than emit spurious warnings.
+fn known_top_level_config_keys() -> Option<std::collections::BTreeSet<String>> {
+    let base: Config = serde_yaml::from_str("{}").ok()?;
+    let serde_yaml::Value::Mapping(serialized) = serde_yaml::to_value(&base).ok()? else {
+        return None;
+    };
+    let mut known: std::collections::BTreeSet<String> = serialized
+        .keys()
+        .filter_map(|k| k.as_str().map(str::to_string))
+        .collect();
+    // Accepted on input but excluded from serialization (skip_serializing[_if])
+    // or kept only for backward-compatible deprecation warnings.
+    for k in ["timezone", "override_timezone", "web_auth_token"] {
+        known.insert(k.to_string());
+    }
+    // Sanity guard: a healthy Config has many keys; if we somehow derived only
+    // a handful, treat the set as unreliable and skip the check.
+    if known.len() < 5 {
+        return None;
+    }
+    Some(known)
+}
+
+/// Soft-validate top-level config keys: serde silently ignores unknown fields,
+/// so a typo like `discrod:` is otherwise invisible. Returns one human-readable
+/// warning per unrecognized key (with a did-you-mean suggestion when close).
+/// Does not fail the load.
+fn unknown_top_level_key_warnings(map: &serde_yaml::Mapping) -> Vec<String> {
+    let Some(known) = known_top_level_config_keys() else {
+        return Vec::new();
+    };
+    let candidates: Vec<String> = known.iter().cloned().collect();
+    let mut warnings = Vec::new();
+    for key in map.keys() {
+        let Some(name) = key.as_str() else { continue };
+        if known.contains(name) {
+            continue;
+        }
+        match suggest_closest(name, &candidates) {
+            Some(best) => warnings.push(format!(
+                "Unknown config key `{name}` (ignored) — did you mean `{best}`?"
+            )),
+            None => warnings.push(format!("Unknown config key `{name}` (ignored).")),
+        }
+    }
+    warnings
 }
 
 /// Extract `(kind, token)` from a serde "unknown variant/field `X`" message.
@@ -4329,5 +4384,51 @@ discord_allowed_channels: [111, 222]
             PathBuf::from(config.skills_dir.unwrap()),
             home.join("skills")
         );
+    }
+
+    fn mapping_of(yaml: &str) -> serde_yaml::Mapping {
+        serde_yaml::from_str::<serde_yaml::Value>(yaml)
+            .unwrap()
+            .as_mapping()
+            .unwrap()
+            .clone()
+    }
+
+    #[test]
+    fn unknown_top_level_key_is_flagged() {
+        let map = mapping_of("definitely_not_a_key: true\napi_key: k\n");
+        let warnings = unknown_top_level_key_warnings(&map);
+        assert!(
+            warnings.iter().any(|w| w.contains("definitely_not_a_key")),
+            "expected an unknown-key warning, got: {warnings:?}"
+        );
+        // A real key in the same document must not be flagged.
+        assert!(
+            !warnings.iter().any(|w| w.contains("`api_key`")),
+            "api_key should be recognized, got: {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn unknown_key_gets_did_you_mean() {
+        // `api_ky` is one edit away from the real `api_key`.
+        let map = mapping_of("api_ky: k\n");
+        let warnings = unknown_top_level_key_warnings(&map);
+        assert!(
+            warnings
+                .iter()
+                .any(|w| w.contains("api_ky") && w.contains("did you mean `api_key`")),
+            "expected a did-you-mean suggestion, got: {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn known_top_level_keys_produce_no_warnings() {
+        // A spread of real keys: plain fields, a nested struct, the flattened
+        // clawhub_* keys, and the skip-serialized timezone fields.
+        let yaml = "api_key: k\ntelegram_bot_token: t\nclawhub_registry: https://x\n\
+timezone: UTC\noverride_timezone: UTC\nsandbox:\n  enabled: false\n";
+        let warnings = unknown_top_level_key_warnings(&mapping_of(yaml));
+        assert!(warnings.is_empty(), "unexpected warnings: {warnings:?}");
     }
 }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -532,4 +532,38 @@ mod tests {
         let msgs = load_messages(raw).unwrap();
         assert_eq!(msgs.len(), 1);
     }
+
+    /// Guards against example-rot. The negative example fixtures in
+    /// docs/test/eval-fixtures/negative/ exist to demonstrate failing
+    /// trajectories, but the CI gate scans the parent dir non-recursively and
+    /// never runs them — so without this test, an edit that made them pass
+    /// would go unnoticed. Keep them failing their advertised checks.
+    #[test]
+    fn negative_fixture_files_still_fail() {
+        let cases = [
+            ("dangling-tool-use.json", "no_dangling_tool_use"),
+            ("stuck-loop.json", "no_tool_call_loop"),
+        ];
+        for (file, expected_check) in cases {
+            let path = format!(
+                "{}/docs/test/eval-fixtures/negative/{}",
+                env!("CARGO_MANIFEST_DIR"),
+                file
+            );
+            let raw =
+                std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("reading {path}: {e}"));
+            let messages =
+                load_messages(&raw).unwrap_or_else(|e| panic!("parsing {path}: {e}"));
+            let r = evaluate(file, &messages, &EvalThresholds::default());
+            assert!(
+                !r.passed,
+                "{file} unexpectedly passed; it must demonstrate a failing trajectory"
+            );
+            assert!(
+                r.checks.iter().any(|c| c.name == expected_check && !c.passed),
+                "{file} did not fail its expected check {expected_check}; checks: {:?}",
+                r.checks
+            );
+        }
+    }
 }


### PR DESCRIPTION
Small, independent quality fixes surfaced while triaging the unreleased commits on `main`.

## 1. Surface clawhub install gate + VirusTotal warnings (`9c83cb7`)
`install_skill` computed the gate-check result (missing required commands / env vars / unsupported OS) and the VirusTotal flag, then **discarded both** (two `TODO`s in `install.rs`). A skill with unmet requirements — or one flagged by ≥3 VirusTotal vendors / with a pending scan — installed silently with no caution shown. Now threaded through `InstallResult { warnings }` and printed in both the `skill install` CLI and the agent install tool. Removes the unused `GateWarning`/`SecurityWarning` placeholders.

## 2. Guard eval negative fixtures against rot (`05966f1`)
The CI "Trajectory eval gate" scans `docs/test/eval-fixtures` **non-recursively** (by design), so the negative fixtures in `negative/` (`dangling-tool-use.json`, `stuck-loop.json`) are never executed and could silently stop failing. Adds a test that loads both files and asserts each still fails its advertised check.

## 3. Warn on unrecognized top-level config keys (`f518fcc`)
serde silently ignores unknown fields, so a typo like `discrod:` loaded without complaint and the #421 did-you-mean help never fired for the common misspelled-key case. `deny_unknown_fields` can't be used here because `Config` flattens `clawhub`. Instead, validate softly after load: derive the accepted top-level key set by serializing a baseline `Config` (auto-synced, including the flattened `clawhub_*` keys) plus the skip-serialized timezone fields, and emit a warning with a did-you-mean suggestion for each unrecognized key. Does not fail the load.

## Testing
- `cargo build` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test -p microclaw-clawhub` ✅ / `cargo test --lib config::` ✅ (81 passed) / `eval::tests::negative_fixture_files_still_fail` ✅

https://claude.ai/code/session_0139tsJZ9v1Um6fNrP7K72MZ