### PR TITLE
feat(gateway): warn when systemd lingering is disabled on install

### DIFF
--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -869,6 +869,30 @@ fn assert_systemd_user_available() -> Result<()> {
 }
 
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn warn_if_linger_disabled() {
+    // Without lingering, systemd stops user services once the last login
+    // session ends, so the gateway dies after SSH logout on headless servers.
+    let Ok(user) = std::env::var("USER") else {
+        return;
+    };
+    let Ok(output) = run_command("loginctl", &["show-user", &user, "--property=Linger"]) else {
+        return;
+    };
+    if !output.status.success() {
+        return;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    if stdout.lines().any(|line| line.trim() == "Linger=no") {
+        println!(
+            "Warning: lingering is disabled for user '{}', so the gateway service will stop after your last login session ends.",
+            user
+        );
+        println!("  To keep it running 24/7, enable lingering:");
+        println!("    sudo loginctl enable-linger {}", user);
+    }
+}
+
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 fn linux_unit_path() -> Result<PathBuf> {
     let home = std::env::var("HOME").context("HOME is not set")?;
     Ok(PathBuf::from(home)
@@ -982,6 +1006,7 @@ fn install_linux(ctx: &ServiceContext, opts: &InstallOptions) -> Result<()> {
         "Installed and started gateway service: {}",
         unit_path.display()
     );
+    warn_if_linger_disabled();
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

User-level systemd services stop once the last login session ends, so the gateway dies after SSH logout on headless servers. Users see this as the bot "stopping on its own" after a few idle hours, only coming back when they SSH in again (which recreates the user session).

After a successful Linux install, `microclaw gateway install` now checks the user's `Linger` property via `loginctl` and prints a hint to run `sudo loginctl enable-linger $USER` when it's disabled.

## Details

- New `warn_if_linger_disabled()` in `src/gateway.rs`, called at the end of `install_linux` after the service is enabled and started.
- Best-effort detection: silently skips if `USER` is unset, `loginctl` is missing, or the command fails — never blocks the install.
- Only prints (does not auto-run), since `enable-linger` needs sudo and the installer shouldn't silently escalate privileges.
- Linux-only; no effect on macOS/Windows installs.

## Test plan

- [x] `cargo check` passes
- [ ] Manual: run `microclaw gateway install` on a Linux host without lingering and confirm the warning appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)