### PR TITLE
docs(roadmap): v0.3.0 completion status + v0.4.0 kickoff

### DIFF
--- a/docs/roadmap/v0.3.0-completion-and-v0.4.0-kickoff.md
+++ b/docs/roadmap/v0.3.0-completion-and-v0.4.0-kickoff.md
@@ -1,0 +1,128 @@
+# v0.3.0 Completion & v0.4.0 Kickoff
+
+Status: **planning** · Baseline: v0.2.5 · Companion to
+[`v0.3.0-self-improving-runtime.md`](./v0.3.0-self-improving-runtime.md)
+
+This document does one thing: take the existing v0.3.0 "Self-Improving Runtime" plan, mark
+what has *actually shipped* against the codebase as of v0.2.5, and turn the remainder into a
+short, ordered finish-line list — then name what v0.4.0 opens with. It is a status-and-sequencing
+pass, not a new direction. The strategy is unchanged and still correct:
+
+> A single static Rust binary on a $5 VPS, channel-native, secure-by-default, that gets better
+> the longer it runs — no Python stack, no vector DB, no training cluster.
+
+Do not chase OpenClaw's enterprise-SaaS path or Hermes's training-cluster path. The defensible
+niche is the one neither occupies.
+
+---
+
+## Where v0.3.0 actually stands (verified against code)
+
+| Pillar | Plan item | Status | Evidence in tree |
+|---|---|---|---|
+| **P3** Per-task aux models | compaction / title / vision / reflector slots | ✅ **shipped** | `config.rs` `AuxModels`; PRs #403/#406/#417 |
+| **P1** Self-curating memory | PROFILE injection, capacity caps, sleep-time consolidation, injection scan | ✅ **shipped** | sleep-time #412; reflector via aux #406 |
+| **P5a/c** Eval gate + iteration warnings | `microclaw eval` trajectory gate; 70%/90% budget hints | ✅ **shipped** | `src/eval.rs`; CI gate #408/#410/#414; fixtures in `docs/test/eval-fixtures/` |
+| **P5b** Boundary guardrails | pre-input / pre-tool-call / post-output | 🟡 **partial** | `src/tool_guardrails.rs` `GuardrailController` is wired in `agent_engine.rs` but **warns only** (consecutive `send_message`, tool-error streaks). No blocking policy, no post-output secret/PII scan. |
+| **P4** Sandbox pluralization | Docker / gVisor / SSH backends, defense-in-depth | 🟡 **partial** | `microclaw-tools/sandbox.rs` `SandboxBackend{Auto,Docker}` is implemented and **`bash` routes through `SandboxRouter`** with capability profiles. **gVisor and SSH backends do not exist**; credential-hygiene (4c) not done. Default stays `none`. |
+| **P2** Skill curator | distill skills from recurring trajectories | ⏳ **not started** | no `crates/microclaw-app/src/skill_curator.rs`; only manual `skill audit` (#416) + ClawHub `gate.rs` exist |
+
+**Read of the table:** the cheap, safe, on-by-default two-thirds of v0.3.0 is done. What remains
+are three higher-value / higher-risk items: the **skill curator (P2)**, **finishing the
+guardrail layer (P5b)**, and **extending the sandbox (P4 gVisor/SSH + credential hygiene)**.
+
+---
+
+## Finish line for v0.3.0 (ordered)
+
+### 1. Skill Curator — P2 (the headline, the moat)
+The single most strategic gap: today the runtime *uses* 42 skills and can `skill_manage` them by
+hand, but it cannot yet *create* a skill from its own experience — so the "gets better the longer
+it runs" pitch is not fully true. Every prerequisite already exists.
+
+- New `crates/microclaw-app/src/skill_curator.rs` background loop on the existing `scheduler.rs`
+  cadence. Scan recent trajectories (`session_search` / `messages`) for multi-step patterns
+  (≥5 tool calls recurring across sessions).
+- A lightweight **aux-model** (Pillar 3, already shipped) call decides whether a reusable skill
+  is warranted, and drafts a thin progressive-disclosure `SKILL.md`.
+- Every generated skill goes through the existing ClawHub `gate.rs` scan, is created
+  **disabled**, and creation is restricted to control chats. Stale/never-activated curated
+  skills auto-archive.
+- **Default off.** Writes a per-run report (`docs/reports/`-style).
+
+*Exit:* on a seeded set of repetitive sessions, the curator proposes ≥1 correct,
+security-scanned, disabled-by-default skill with a report; nothing it produces can run without
+explicit activation.
+
+### 2. Finish the guardrail layer — P5b
+The warning-only `GuardrailController` is a good spine; promote it from "advice" to "policy".
+
+- **Pre-tool-call**: argument/policy checks keyed on the existing `risk` levels; allow a
+  configured deny to *block* (not just warn), logged to the audit trail.
+- **Post-output**: secret/PII leak scan before delivery (reuse the path-guard / SSRF deny-list
+  spirit), redact-or-block, configurable, off by default.
+- Combine pre-input with the already-shipped memory injection scan (P1d).
+
+*Exit:* a blocked tool call and a redacted post-output are both covered by tests; all policies
+default off; every decision is auditable.
+
+### 3. Extend the sandbox — P4 (gVisor/SSH + credential hygiene)
+Docker is already wired to `bash`. Close the remaining two:
+
+- **4c credential hygiene** (nanoclaw lesson): the sandboxed process must never receive raw API
+  keys; secrets stay in the host process and are injected only at the egress boundary. *This is
+  the highest-value remaining sandbox item and should land before new backends.*
+- **gVisor (`runsc`)** and **SSH (remote host)** backends behind the existing `SandboxBackend`
+  enum + `doctor` availability check; fail-closed (refuse `exclusive` tools) when a configured
+  backend is unavailable rather than silently using the host.
+
+*Exit:* a path-escape and a network-exfil attempt are both blocked in tests; no API key is
+visible to a sandboxed `bash`; `doctor` validates every configured backend.
+
+---
+
+## v0.4.0 kickoff — Security & governance as a first-class pillar (Track B)
+
+This is the release that best matches the "$5 VPS, self-hosted, secure-by-default" pitch and the
+clearest differentiator vs OpenClaw (enterprise SaaS) and Hermes (training clusters). Align to the
+**OWASP Top 10 for Agentic Applications**; over-permissioning is the root cause of most incidents.
+
+- **Process-wide network egress control.** Promote the existing `web_fetch` SSRF guard
+  (`microclaw-tools` `url_safety.rs` / `website_policy.rs`) into a process-level outbound policy
+  (à la OpenClaw "Proxyline"): block private/metadata destinations by default, allow-list opt-in.
+- **Per-chat / per-agent least-privilege tool authorization.** Build on the shipped auth/scope
+  model (RFC-0001, Phase 1) to scope *tools* to chats and roles, not just web API endpoints.
+- **Tamper-evident audit** is already hash-chained (#418) — extend coverage to guardrail and
+  curator decisions.
+
+### Track C groundwork (long-horizon "8-hour coworker")
+Durable long-task semantics on top of the scheduler/sub-agents: crash recovery, resumable runs,
+first-class progress/ETA. The scheduler **dead-letter queue + replay** (stability board P1) and
+the **non-web channel progress heartbeat** (Phase 3 of
+[`non-web-channel-progress-events-plan.md`](./non-web-channel-progress-events-plan.md)) are the
+concrete next bricks.
+
+### Explicitly still deferred (from #378 Q4 / 2027)
+Live Canvas / A2UI, workspace multi-agent routing, voice wake / menu-bar companion, mobile node
+clients, serverless hibernate backends, full RL trajectory export, ClawHub ratings/signatures.
+
+---
+
+## Sequencing & guarantees
+
+| Order | Item | Release | Risk | Default |
+|---|---|---|---|---|
+| 1 | Skill curator (P2) | v0.3.0 | medium | **off** |
+| 2 | Guardrail policy + post-output scan (P5b) | v0.3.0 | medium | **off** |
+| 3 | Sandbox credential hygiene (P4c) | v0.3.0 | medium | n/a (only when sandbox on) |
+| 4 | gVisor / SSH backends (P4) | v0.3.0→v0.4.0 | high | `none` |
+| 5 | Network egress control (Track B) | v0.4.0 | high | warn-only first |
+| 6 | Per-chat tool authorization (Track B) | v0.4.0 | medium | permissive→opt-in |
+| 7 | Scheduler DLQ replay + progress heartbeat (Track C) | v0.4.0 | medium | off |
+
+**No default behavior change** for existing deployments: every new autonomous or
+isolation-changing feature is off by default; aux-model slots fall back to the main model.
+
+Per-PR checklist (from `feature-completion-tracking-board.md`) applies: `cargo test -q`,
+`npm --prefix web run build`, `node scripts/generate_docs_artifacts.mjs --check`, docs updated,
+rollback note.


### PR DESCRIPTION
## What

Adds `docs/roadmap/v0.3.0-completion-and-v0.4.0-kickoff.md` — a status-and-sequencing pass over the existing "Self-Improving Runtime" plan, **verified against the v0.2.5 tree** (not a new direction).

## Why

The v0.3.0 plan is well underway but the in-repo status was scattered across commits. This consolidates *what actually shipped vs what remains* and turns the remainder into a short, ordered finish line, then names what v0.4.0 opens with.

## Verified status of the 5 pillars

| Pillar | Status | Notes |
|---|---|---|
| P3 per-task aux models | ✅ shipped | `AuxModels` in `config.rs` (#403/#406/#417) |
| P1 self-curating memory | ✅ shipped | sleep-time consolidation #412 |
| P5a/c eval gate + iteration warnings | ✅ shipped | `src/eval.rs`, CI gate #408/#410/#414 |
| P5b boundary guardrails | 🟡 partial | `GuardrailController` wired in `agent_engine.rs` but **warns only** — no blocking policy, no post-output secret/PII scan |
| P4 sandbox pluralization | 🟡 partial | Docker backend **wired to `bash`** via `SandboxRouter`; **gVisor/SSH absent**, credential hygiene (4c) not done |
| P2 skill curator | ⏳ not started | no `skill_curator.rs`; only manual `skill audit` (#416) |

## Ordered finish line (v0.3.0)

1. **Skill curator (P2)** — the headline self-improvement feature; all prerequisites exist
2. **Finish guardrails (P5b)** — promote warn-only controller to blocking policy + post-output leak scan
3. **Sandbox credential hygiene (P4c)** then **gVisor/SSH backends**

## v0.4.0 kickoff

Security & governance as a first-class pillar (OWASP Agentic Top 10): process-wide network egress control, per-chat/per-agent least-privilege tool authorization, extended tamper-evident audit. Plus Track C long-horizon groundwork (scheduler DLQ replay, non-web progress heartbeat).

## Scope

Docs only — no code or behavior change. Every proposed feature remains off by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01513ZfauJzwZ6xSt4wu5kDK)_