### PR TITLE
docs(roadmap): 2026 H2 competitive landscape + intel-driven direction

### DIFF
--- a/docs/roadmap/competitive-landscape-and-direction-2026-h2.md
+++ b/docs/roadmap/competitive-landscape-and-direction-2026-h2.md
@@ -1,0 +1,150 @@
+# Competitive Landscape & Direction — 2026 H2
+
+Status: **strategy** · Date: 2026-06-20 · Companion to
+[`v0.3.0-self-improving-runtime.md`](./v0.3.0-self-improving-runtime.md) and
+[`v0.3.0-completion-and-v0.4.0-kickoff.md`](./v0.3.0-completion-and-v0.4.0-kickoff.md)
+
+A fresh (mid-2026) competitive-intelligence pass on the two reference projects, what it changes
+for MicroClaw, and the resulting direction. Confidence is marked per claim: **[primary]** =
+GitHub API / release pages / major press; **[secondary]** = aggregator/blog only, plausible but
+unverified.
+
+---
+
+## 1. Reference projects — where they actually are (mid-2026)
+
+### OpenClaw — `openclaw/openclaw`
+- **Identity/scale [primary]:** TypeScript/Node local-first personal agent. ~**379.5k stars**,
+  created 2025-11-24, active 2026-06. The single most-starred repo on GitHub. Creator Peter
+  Steinberger joined OpenAI (~Feb 2026); project spun into an **OpenAI-sponsored independent
+  open-source foundation** (TechCrunch, CNBC).
+- **Recent confirmed work (2026.6.1) [primary]:** resilient recovery for interrupted tool calls
+  / stale sessions / compaction handoffs / auth-profile failover; channel restart survival
+  (WhatsApp/iMessage/Discord/QQ/iOS Talk); **Skill Workshop** (proposal→approval workflow);
+  **Workboard** multi-agent coordination with task-backed runs + **SQLite-backed plugin state**;
+  cron migrated to SQLite; plugin-boundary isolation.
+- **`openclaw/proxyline` [primary]:** a standalone TS library for **process-global egress
+  control** — replaces the Node http/https + fetch global dispatcher, **managed (fail-closed)**
+  vs ambient modes, `explain()` with credential redaction, blocks metadata/private/loopback
+  ranges. Premise: env-var proxies are best-effort and silently bypassable, so policy belongs in
+  code.
+- **Roadmap [secondary]:** deterministic multi-agent orchestration (contract-governed, *away*
+  from chaotic "agent armies"); Plugin SDK v2 (typed contracts); ChromaDB vector memory (today a
+  community skill, not core); operator web dashboard; enterprise (Teams/Salesforce/SSO-SAML/RBAC/
+  audit); skill trust-scoring ("ClawForge").
+- **Direction:** professionalizing on two axes at once — **security/operability** and
+  **enterprise readiness** — while staying self-hostable. Likely open-core + managed-hosting.
+
+### Hermes Agent — `NousResearch/hermes-agent`
+- **Identity/scale [primary]:** Python (+TS) self-hosted, model-agnostic "agent that grows with
+  you." ~**197.7k stars**, created 2025-07, active 2026-06. Rapid cadence (~weekly/biweekly).
+- **Recent confirmed work [primary]:** v0.17 "Reach" (iMessage via Photon, **Raft** agent-network
+  gateway, background/async subagents); v0.16 "Surface" (native desktop app + web admin
+  dashboard); v0.15 "Velocity" (**core loop −76%**, session_search rebuilt ~4500× faster,
+  **promptware injection defense**, secrets via Bitwarden, skill bundles).
+- **The strategic core [primary]:** Hermes Agent is explicitly a **training-data + RL flywheel** —
+  batch parallel **trajectory generation**, compression, **ShareGPT/Atropos export**; companion
+  `hermes-agent-self-evolution` repo evolves **skills → prompts → tool code** via **DSPy + GEPA**
+  (genetic-Pareto, human-in-the-loop PR-gated). Connected stack: Hermes Agent → **Atropos** (RL
+  environments) → **Psyche/DisTrO** (decentralized low-bandwidth training of next Hermes models).
+- **Direction:** own the full open-source loop **agent runtime → RL infra → decentralized
+  training**; turn everyday agent behavior into trainable data. Consumer hook = "grows with you";
+  long game = vertically integrated, crypto-adjacent counter-position to closed labs.
+
+---
+
+## 2. What the landscape tells us (convergent signals)
+
+1. **Egress control is now an industry-validated pattern.** OpenClaw shipped a dedicated
+   `proxyline` library for fail-closed, auditable, in-code network policy. This is *exactly*
+   MicroClaw's planned v0.4.0 Track B item — **the direction is confirmed.**
+2. **Multi-agent is converging on deterministic, contract-governed orchestration**, explicitly
+   moving away from chaotic swarms (OpenClaw Workboard; Hermes Raft/Kanban). The value is in
+   *governance*, not in spawning more agents.
+3. **Resilience/recovery is now table stakes**, not a nice-to-have. OpenClaw's headline 2026.6.1
+   work was interrupted-tool-call recovery and restart survival.
+4. **Approval-gated, security-scanned skill creation is the consensus safe pattern** (OpenClaw
+   Skill Workshop proposal→approval; Hermes PR-gated self-evolution). Validates "curator creates
+   *disabled* skills."
+5. **Self-improvement is the headline of the category** — but the two leaders take very different
+   routes: Hermes pushes all the way to **evolving its own tool code + RL training**; OpenClaw
+   keeps it to approval-gated skills.
+6. **Both already moved runtime state into SQLite** — MicroClaw has been SQLite-native from day
+   one. A structural head start on the very thing they retrofitted.
+
+## 3. MicroClaw's position — unchanged thesis, sharpened
+
+Both leaders are an order of magnitude larger in mindshare (379k / 197k stars) and are
+Python/TypeScript. **MicroClaw cannot and should not compete on hype or breadth.** Its moat is
+the one neither occupies:
+
+> A single **static Rust binary** on a **$5 VPS** (1 vCPU / 1 GB) — channel-native,
+> **secure-by-default**, that **gets better the longer it runs** — no Python stack, no vector DB,
+> no training cluster.
+
+The intel *reinforces* this. Where the leaders bolt on egress control as a separate library
+(Proxyline) or retrofit SQLite, MicroClaw can ship the same capabilities **natively, in one
+process, with a fraction of the footprint** — and that footprint *is* the product.
+
+### Explicit non-goals (do not chase)
+- **No RL/training flywheel** (Hermes/Atropos/Psyche). Keep only a cheap, deferred
+  **Atropos-compatible trajectory *export schema*** as a researcher affordance — no training-side
+  investment.
+- **No code self-modification / GEPA-style evolution of the agent's own tool code.** It is
+  antithetical to a secure-by-default pitch. Self-improvement stays scoped to **skills + memory**,
+  approval-gated.
+- **No enterprise-SaaS build-out** (ChromaDB core, SSO/SAML/Teams/Salesforce, operator
+  dashboards as a product). Stay self-hostable; leave hosting to operators.
+- **No "agent army."** Orchestration value is governance and contracts, not agent count.
+
+---
+
+## 4. Direction — confirmed plan + intel-driven adjustments
+
+The existing v0.3.0→v0.4.0 plan holds. The intel produces **four adjustments**, not a rewrite:
+
+| # | Adjustment | Driven by | Effect on plan |
+|---|---|---|---|
+| A | **Promote egress control to a headline v0.4.0 feature** and frame it as native/in-process/fail-closed (vs Proxyline-as-library). | OpenClaw Proxyline [primary] | Was already Track B; raise its prominence and lead with it. |
+| B | **Raise Track C (resilience/recovery) priority to "table stakes."** Interrupted-tool-call recovery, resumable runs, scheduler DLQ replay move up. | OpenClaw 2026.6.1 recovery focus [primary] | Track C groundwork starts *in parallel with* v0.3.0 finish, not after. |
+| C | **Formalize `subagents_orchestrate` into a contract-governed orchestration story** (a Workboard analog: declared tasks, dependencies, deterministic routing, fan-in). | OpenClaw Workboard + Hermes Raft [primary] | New v0.4.0 line item; builds on existing subagents. |
+| D | **Keep the skill curator deterministic and skills-only**; explicitly *reject* code/prompt self-evolution. Add the trajectory-export schema as a deferred researcher affordance. | Hermes self-evolution as cautionary contrast [primary] | Tightens P2 scope; no new heavy work. |
+
+### Resulting sequence
+
+**v0.3.0 finish (unchanged order, from the completion doc):**
+1. Skill curator (P2) — deterministic, skills-only, creates *disabled* + security-scanned skills.
+2. Finish guardrails (P5b) — warn→block policy + post-output secret/PII scan.
+3. Sandbox credential hygiene (P4c), then gVisor/SSH backends.
+
+**v0.4.0 — "Secure-by-default, durable, governed" (intel-adjusted):**
+4. **Native network egress control** (Track B headline; fail-closed, auditable, in-process).
+5. **Per-chat / per-agent least-privilege tool authorization** (OWASP Agentic Top 10).
+6. **Resilience/recovery** (Track C, now table stakes): interrupted-tool-call recovery, resumable
+   long runs, scheduler **DLQ + replay**, non-web progress heartbeat.
+7. **Contract-governed orchestration** (formalize `subagents_orchestrate`: declared tasks,
+   dependencies, deterministic fan-in).
+
+**Deferred (researcher/long-horizon):** Atropos-compatible trajectory *export schema* only;
+Live Canvas / A2UI, mobile nodes, serverless hibernate (per #378 Q4/2027).
+
+### Guarantees (unchanged)
+No default behavior change; every new autonomous or isolation-changing feature off by default;
+aux-model slots fall back to main. Per-PR checklist from `feature-completion-tracking-board.md`
+applies.
+
+---
+
+## 5. Sources
+
+**OpenClaw [primary]:** github.com/openclaw/openclaw · github.com/openclaw/openclaw/releases/tag/v2026.6.1
+· github.com/openclaw/proxyline · techcrunch.com/2026/02/15/openclaw-creator-peter-steinberger-joins-openai
+· cnbc.com (2026-02-15). **[secondary roadmap]:** tencentcloud techpedia 141252; blink.new; skywork.ai.
+
+**Hermes Agent [primary]:** github.com/NousResearch/hermes-agent · hermes-agent.nousresearch.com/docs
+· github.com/NousResearch/hermes-agent-self-evolution · github.com/NousResearch/atropos ·
+nousresearch.com/nous-psyche. **[secondary]:** marktechpost (2026-06-03 Hermes Desktop); petronellatech tracker.
+
+*Caveat:* both projects' roadmap specifics rest on secondary sources (official docs/blogs blocked
+automated fetching); confirmed release content and repo metadata are primary. Re-verify before
+treating any [secondary] item as load-bearing.

--- a/docs/roadmap/v0.3.0-completion-and-v0.4.0-kickoff.md
+++ b/docs/roadmap/v0.3.0-completion-and-v0.4.0-kickoff.md
@@ -1,0 +1,128 @@
+# v0.3.0 Completion & v0.4.0 Kickoff
+
+Status: **planning** · Baseline: v0.2.5 · Companion to
+[`v0.3.0-self-improving-runtime.md`](./v0.3.0-self-improving-runtime.md)
+
+This document does one thing: take the existing v0.3.0 "Self-Improving Runtime" plan, mark
+what has *actually shipped* against the codebase as of v0.2.5, and turn the remainder into a
+short, ordered finish-line list — then name what v0.4.0 opens with. It is a status-and-sequencing
+pass, not a new direction. The strategy is unchanged and still correct:
+
+> A single static Rust binary on a $5 VPS, channel-native, secure-by-default, that gets better
+> the longer it runs — no Python stack, no vector DB, no training cluster.
+
+Do not chase OpenClaw's enterprise-SaaS path or Hermes's training-cluster path. The defensible
+niche is the one neither occupies.
+
+---
+
+## Where v0.3.0 actually stands (verified against code)
+
+| Pillar | Plan item | Status | Evidence in tree |
+|---|---|---|---|
+| **P3** Per-task aux models | compaction / title / vision / reflector slots | ✅ **shipped** | `config.rs` `AuxModels`; PRs #403/#406/#417 |
+| **P1** Self-curating memory | PROFILE injection, capacity caps, sleep-time consolidation, injection scan | ✅ **shipped** | sleep-time #412; reflector via aux #406 |
+| **P5a/c** Eval gate + iteration warnings | `microclaw eval` trajectory gate; 70%/90% budget hints | ✅ **shipped** | `src/eval.rs`; CI gate #408/#410/#414; fixtures in `docs/test/eval-fixtures/` |
+| **P5b** Boundary guardrails | pre-input / pre-tool-call / post-output | 🟡 **partial** | `src/tool_guardrails.rs` `GuardrailController` is wired in `agent_engine.rs` but **warns only** (consecutive `send_message`, tool-error streaks). No blocking policy, no post-output secret/PII scan. |
+| **P4** Sandbox pluralization | Docker / gVisor / SSH backends, defense-in-depth | 🟡 **partial** | `microclaw-tools/sandbox.rs` `SandboxBackend{Auto,Docker}` is implemented and **`bash` routes through `SandboxRouter`** with capability profiles. **gVisor and SSH backends do not exist**; credential-hygiene (4c) not done. Default stays `none`. |
+| **P2** Skill curator | distill skills from recurring trajectories | ⏳ **not started** | no `crates/microclaw-app/src/skill_curator.rs`; only manual `skill audit` (#416) + ClawHub `gate.rs` exist |
+
+**Read of the table:** the cheap, safe, on-by-default two-thirds of v0.3.0 is done. What remains
+are three higher-value / higher-risk items: the **skill curator (P2)**, **finishing the
+guardrail layer (P5b)**, and **extending the sandbox (P4 gVisor/SSH + credential hygiene)**.
+
+---
+
+## Finish line for v0.3.0 (ordered)
+
+### 1. Skill Curator — P2 (the headline, the moat)
+The single most strategic gap: today the runtime *uses* 42 skills and can `skill_manage` them by
+hand, but it cannot yet *create* a skill from its own experience — so the "gets better the longer
+it runs" pitch is not fully true. Every prerequisite already exists.
+
+- New `crates/microclaw-app/src/skill_curator.rs` background loop on the existing `scheduler.rs`
+  cadence. Scan recent trajectories (`session_search` / `messages`) for multi-step patterns
+  (≥5 tool calls recurring across sessions).
+- A lightweight **aux-model** (Pillar 3, already shipped) call decides whether a reusable skill
+  is warranted, and drafts a thin progressive-disclosure `SKILL.md`.
+- Every generated skill goes through the existing ClawHub `gate.rs` scan, is created
+  **disabled**, and creation is restricted to control chats. Stale/never-activated curated
+  skills auto-archive.
+- **Default off.** Writes a per-run report (`docs/reports/`-style).
+
+*Exit:* on a seeded set of repetitive sessions, the curator proposes ≥1 correct,
+security-scanned, disabled-by-default skill with a report; nothing it produces can run without
+explicit activation.
+
+### 2. Finish the guardrail layer — P5b
+The warning-only `GuardrailController` is a good spine; promote it from "advice" to "policy".
+
+- **Pre-tool-call**: argument/policy checks keyed on the existing `risk` levels; allow a
+  configured deny to *block* (not just warn), logged to the audit trail.
+- **Post-output**: secret/PII leak scan before delivery (reuse the path-guard / SSRF deny-list
+  spirit), redact-or-block, configurable, off by default.
+- Combine pre-input with the already-shipped memory injection scan (P1d).
+
+*Exit:* a blocked tool call and a redacted post-output are both covered by tests; all policies
+default off; every decision is auditable.
+
+### 3. Extend the sandbox — P4 (gVisor/SSH + credential hygiene)
+Docker is already wired to `bash`. Close the remaining two:
+
+- **4c credential hygiene** (nanoclaw lesson): the sandboxed process must never receive raw API
+  keys; secrets stay in the host process and are injected only at the egress boundary. *This is
+  the highest-value remaining sandbox item and should land before new backends.*
+- **gVisor (`runsc`)** and **SSH (remote host)** backends behind the existing `SandboxBackend`
+  enum + `doctor` availability check; fail-closed (refuse `exclusive` tools) when a configured
+  backend is unavailable rather than silently using the host.
+
+*Exit:* a path-escape and a network-exfil attempt are both blocked in tests; no API key is
+visible to a sandboxed `bash`; `doctor` validates every configured backend.
+
+---
+
+## v0.4.0 kickoff — Security & governance as a first-class pillar (Track B)
+
+This is the release that best matches the "$5 VPS, self-hosted, secure-by-default" pitch and the
+clearest differentiator vs OpenClaw (enterprise SaaS) and Hermes (training clusters). Align to the
+**OWASP Top 10 for Agentic Applications**; over-permissioning is the root cause of most incidents.
+
+- **Process-wide network egress control.** Promote the existing `web_fetch` SSRF guard
+  (`microclaw-tools` `url_safety.rs` / `website_policy.rs`) into a process-level outbound policy
+  (à la OpenClaw "Proxyline"): block private/metadata destinations by default, allow-list opt-in.
+- **Per-chat / per-agent least-privilege tool authorization.** Build on the shipped auth/scope
+  model (RFC-0001, Phase 1) to scope *tools* to chats and roles, not just web API endpoints.
+- **Tamper-evident audit** is already hash-chained (#418) — extend coverage to guardrail and
+  curator decisions.
+
+### Track C groundwork (long-horizon "8-hour coworker")
+Durable long-task semantics on top of the scheduler/sub-agents: crash recovery, resumable runs,
+first-class progress/ETA. The scheduler **dead-letter queue + replay** (stability board P1) and
+the **non-web channel progress heartbeat** (Phase 3 of
+[`non-web-channel-progress-events-plan.md`](./non-web-channel-progress-events-plan.md)) are the
+concrete next bricks.
+
+### Explicitly still deferred (from #378 Q4 / 2027)
+Live Canvas / A2UI, workspace multi-agent routing, voice wake / menu-bar companion, mobile node
+clients, serverless hibernate backends, full RL trajectory export, ClawHub ratings/signatures.
+
+---
+
+## Sequencing & guarantees
+
+| Order | Item | Release | Risk | Default |
+|---|---|---|---|---|
+| 1 | Skill curator (P2) | v0.3.0 | medium | **off** |
+| 2 | Guardrail policy + post-output scan (P5b) | v0.3.0 | medium | **off** |
+| 3 | Sandbox credential hygiene (P4c) | v0.3.0 | medium | n/a (only when sandbox on) |
+| 4 | gVisor / SSH backends (P4) | v0.3.0→v0.4.0 | high | `none` |
+| 5 | Network egress control (Track B) | v0.4.0 | high | warn-only first |
+| 6 | Per-chat tool authorization (Track B) | v0.4.0 | medium | permissive→opt-in |
+| 7 | Scheduler DLQ replay + progress heartbeat (Track C) | v0.4.0 | medium | off |
+
+**No default behavior change** for existing deployments: every new autonomous or
+isolation-changing feature is off by default; aux-model slots fall back to the main model.
+
+Per-PR checklist (from `feature-completion-tracking-board.md`) applies: `cargo test -q`,
+`npm --prefix web run build`, `node scripts/generate_docs_artifacts.mjs --check`, docs updated,
+rollback note.


### PR DESCRIPTION
## What

Adds `docs/roadmap/competitive-landscape-and-direction-2026-h2.md` — a mid-2026 competitive-intelligence pass on the two reference projects (OpenClaw, Hermes Agent) and the intel-driven adjustments to MicroClaw's direction.

## Intel summary (confidence-marked in the doc)

- **OpenClaw** [primary]: TS, ~379.5k stars, OpenAI-sponsored foundation. Professionalizing on **security/operability + enterprise**. Confirmed 2026.6.1: Workboard multi-agent coordination, Skill Workshop approval gates, SQLite-backed state, interrupted-tool-call recovery; plus the standalone **proxyline** process-global egress-control library (fail-closed/SSRF).
- **Hermes Agent** [primary]: Python, ~197.7k stars, Nous Research. A **training-data + RL flywheel** (Hermes Agent → Atropos → Psyche) with `hermes-agent-self-evolution` (DSPy+GEPA evolving skills→prompts→tool code).

## Convergent signals

Egress control is now industry-validated · multi-agent converging on **contract-governed** orchestration (not agent swarms) · resilience/recovery is **table stakes** · approval-gated skill creation is consensus · both retrofitted SQLite (MicroClaw was SQLite-native from day one).

## Direction

Thesis **unchanged** — static Rust binary, $5 VPS, secure-by-default, gets better the longer it runs. Four intel-driven **adjustments** (not a rewrite):

| | Adjustment |
|---|---|
| A | Promote **native egress control** to a headline v0.4.0 feature (vs Proxyline-as-library) |
| B | Raise **resilience/recovery** (Track C) to table stakes — start in parallel with v0.3.0 finish |
| C | Formalize `subagents_orchestrate` into **contract-governed orchestration** (Workboard analog) |
| D | Keep curator **deterministic + skills-only**; reject code self-evolution |

**Explicit non-goals:** no RL/training flywheel, no code self-modification (GEPA), no enterprise SaaS, no "agent army."

## Scope

Docs only — no code or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01513ZfauJzwZ6xSt4wu5kDK)_